### PR TITLE
replaces falling falcons in blurb text with solar devils

### DIFF
--- a/code/modules/maptext_alerts/text_blurbs.dm
+++ b/code/modules/maptext_alerts/text_blurbs.dm
@@ -14,7 +14,7 @@ exempt_ztraits = trait or list of traits of zlevels where any marines don't see 
 shouldn't see the ship marines' drop message. Ex. ZTRAIT_GROUND by default.
 unit = the unit the marines are from. FF, Dust Raiders etc. Military crew see this.
 base = the base the marines are staging from. The ship, Whiskey Outpost etc. Noncombat crew see this.**/
-/proc/show_blurb_uscm(list/exempt_ztraits = ZTRAIT_GROUND, unit = "2nd Bat. 'Falling Falcons'", base = station_name)
+/proc/show_blurb_uscm(list/exempt_ztraits = ZTRAIT_GROUND, unit = "3rd Bat. 'Solar Devils'", base = station_name)
 	if(!islist(exempt_ztraits))
 		exempt_ztraits = list(exempt_ztraits)
 	var/list/exempt_zlevels = SSmapping.levels_by_any_trait(exempt_ztraits)

--- a/code/modules/maptext_alerts/text_blurbs.dm
+++ b/code/modules/maptext_alerts/text_blurbs.dm
@@ -14,7 +14,7 @@ exempt_ztraits = trait or list of traits of zlevels where any marines don't see 
 shouldn't see the ship marines' drop message. Ex. ZTRAIT_GROUND by default.
 unit = the unit the marines are from. FF, Dust Raiders etc. Military crew see this.
 base = the base the marines are staging from. The ship, Whiskey Outpost etc. Noncombat crew see this.**/
-/proc/show_blurb_uscm(list/exempt_ztraits = ZTRAIT_GROUND, unit = "3rd Bat. 'Solar Devils'", base = station_name)
+/proc/show_blurb_uscm(list/exempt_ztraits = ZTRAIT_GROUND, unit = "2nd Bat. 'Falling Falcons'", base = station_name)
 	if(!islist(exempt_ztraits))
 		exempt_ztraits = list(exempt_ztraits)
 	var/list/exempt_zlevels = SSmapping.levels_by_any_trait(exempt_ztraits)


### PR DESCRIPTION
i am actually not sure if it's the correct unit name but it's still better than falling falcons and if it is infact incorrect i'll happily change the pr

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
spellcheck: We are Solar Devils, not Falling Falcons!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
