### PR TITLE
Directional Lock no longer slows you

### DIFF
--- a/code/__DEFINES/pain.dm
+++ b/code/__DEFINES/pain.dm
@@ -3,7 +3,6 @@
 // How slow we go from losing a limb
 #define MOVE_REDUCTION_LIMB_DESTROYED 4
 #define MOVE_REDUCTION_LIMB_BROKEN 1.5
-#define MOVE_REDUCTION_DIRECTION_LOCKED 1
 #define MOVE_REDUCTION_LIMB_SPLINTED 0.5
 
 // Traumatic shock reduction for different reagents

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -165,8 +165,6 @@
 		if(mob.next_move_slowdown)
 			move_delay += mob.next_move_slowdown
 			mob.next_move_slowdown = 0
-		if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
-			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED // by Geeves
 
 		mob.cur_speed = Clamp(10/(move_delay + 0.5), MIN_SPEED, MAX_SPEED)
 		//We are now going to move


### PR DESCRIPTION
See Above

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

see title

# Explain why it's good for the game

Dirlocking was added due to it being abused by marines and xenos to make their sprites less readable/harder to see (sadar facing north, lurkers facing north etc)

with the only threats being AI, this can be removed and  players can use it freely for RP such as backing up from a fuel tank while facing it (without a massive movespeed penalty!) or forming a firing line without the entire thing falling apart when someone pushes everyone

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Directional Locking no longer gives you a slowdown. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
