### PR TITLE
upp spec skill no longer required to fire upp machinegun

### DIFF
--- a/code/modules/projectiles/guns/misc.dm
+++ b/code/modules/projectiles/guns/misc.dm
@@ -273,10 +273,6 @@
 	if(!skillcheck(user, SKILL_FIREARMS, SKILL_FIREARMS_TRAINED))
 		to_chat(user, SPAN_WARNING("You don't seem to know how to use [src]..."))
 		return 0
-	if(!skillcheck(user, SKILL_SPEC_WEAPONS, SKILL_SPEC_ALL) && user.skills.get_skill_level(SKILL_SPEC_WEAPONS) != SKILL_SPEC_UPP)
-		to_chat(user, SPAN_WARNING("You don't seem to know how to use [src]..."))
-		return 0
-
 
 /obj/effect/syringe_gun_dummy
 	name = ""


### PR DESCRIPTION
some people requested it 
it's not that good of a weapon in pve to lock it behind a skill check