### PR TITLE
alt clicking bed roll allows you to sit on it instead of lying down

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -411,6 +411,14 @@ var/global/list/activated_medevac_stretchers = list()
 	buckling_y = 0
 	foldabletype = /obj/item/roller/bedroll
 	accepts_bodybag = FALSE
+	buckling_sound = "rustle"
+
+/obj/structure/bed/bedroll/clicked(mob/user, list/mods)
+	if(mods["alt"] && !buckled_mob)
+		buckle_lying = !buckle_lying
+		to_chat(user, SPAN_NOTICE("You tuck [src] for comfortable [buckle_lying ? "lying" : "sitting"]."))
+		return TRUE
+	return ..()
 
 /obj/item/roller/bedroll
 	name = "folded bedroll"


### PR DESCRIPTION
with the addition of "sit down to eat faster" mechanic it became kinda hard to eat mres groundside so i thought that it would be nice to give some utility to a pretty useless fluff item