### PR TITLE
moves m4ra to sgt room

### DIFF
--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -2080,9 +2080,7 @@
 /area/golden_arrow/supply)
 "mc" = (
 /obj/structure/surface/rack,
-/obj/item/weapon/gun/rifle/m4ra/pve{
-	pixel_y = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -2838,17 +2836,6 @@
 	icon_state = "plate"
 	},
 /area/golden_arrow/hangar)
-"qK" = (
-/obj/structure/closet/coffin/woodencrate,
-/obj/item/ammo_magazine/rifle/m4ra/pve,
-/obj/item/ammo_magazine/rifle/m4ra/pve,
-/obj/item/ammo_magazine/rifle/m4ra/pve,
-/obj/item/ammo_magazine/rifle/m4ra/pve,
-/obj/item/ammo_magazine/rifle/m4ra/pve,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/golden_arrow/platoon_sergeant)
 "qQ" = (
 /turf/open/floor/almayer{
 	icon_state = "cargo_arrow"
@@ -6110,8 +6097,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/cryo_cells)
 "Kl" = (
+/obj/structure/closet/coffin/woodencrate,
+/obj/item/ammo_magazine/rifle/m4ra/pve,
+/obj/item/ammo_magazine/rifle/m4ra/pve,
+/obj/item/ammo_magazine/rifle/m4ra/pve,
+/obj/item/ammo_magazine/rifle/m4ra/pve,
+/obj/item/ammo_magazine/rifle/m4ra/pve,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/photocopier,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -8182,6 +8174,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/squad_one)
 "UK" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/rifle/m4ra/pve{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light{
 	dir = 4
 	},
@@ -16760,7 +16757,7 @@ gI
 BK
 sC
 mc
-qK
+KQ
 bw
 KQ
 QS


### PR DESCRIPTION
# About the pull request

as mentioned in pr #89, gunny's hogging gun, moving to sgt to allow for better distro
if this does not work, i will make it a random spawn for armory shotty or just make it 50/50 one squad shotty one m4ra

# Explain why it's good for the game

people going gunny for special gun is very, VERY bad.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/54826962/1385287c-e6cb-4487-a42e-38d3daa6a10a)


</details>


# Changelog


:cl:
balance: M4RA to sgts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
