### PR TITLE
Flare Storage Buff

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1526,8 +1526,8 @@
 /obj/item/storage/belt/gun/flaregun
 	name = "\improper M276 pattern M82F flare gun holster rig"
 	desc = "The M276 is the standard load-bearing equipment of the USCM. It consists of a modular belt with various clips. This version is for the M82F flare gun."
-	storage_slots = 17
-	max_storage_space = 20
+	storage_slots = 28
+	max_storage_space = 31
 	icon_state = "m82f_holster"
 	item_state = "s_marinebelt"
 	can_hold = list(

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -548,11 +548,11 @@
 
 /obj/item/storage/box/m94
 	name = "\improper M94 marking flare pack"
-	desc = "A packet of eight M94 Marking Flares. Carried by USCM soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp."
+	desc = "A packet of twenty one M94 Marking Flares. Carried by USCM soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp."
 	icon_state = "m94"
 	w_class = SIZE_MEDIUM
-	storage_slots = 8
-	max_storage_space = 8
+	storage_slots = 21
+	max_storage_space = 21
 	can_hold = list(/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare/signal)
 
 /obj/item/storage/box/m94/fill_preset_inventory()
@@ -568,7 +568,7 @@
 
 /obj/item/storage/box/m94/signal
 	name = "\improper M89-S signal flare pack"
-	desc = "A packet of eight M89-S Signal Marking Flares."
+	desc = "A packet of twenty one M89-S Signal Marking Flares."
 	icon_state = "m89"
 
 /obj/item/storage/box/m94/signal/fill_preset_inventory()

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1084,8 +1084,8 @@
 	name = "flare pouch"
 	desc = "A pouch designed to hold flares. Refillable with an M94 flare pack."
 	max_w_class = SIZE_SMALL
-	storage_slots = 8
-	max_storage_space = 8
+	storage_slots = 21
+	max_storage_space = 21
 	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD
 	icon_state = "flare"
 	can_hold = list(/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare/signal)

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -239,7 +239,7 @@
 	icon_state = "secure_crate"
 
 /obj/structure/largecrate/supply/supplies/flares
-	name = "Flare supply crate (x200)"
+	name = "Flare supply crate (x525)"
 	desc = "A supply crate containing two crates of flares."
 	supplies = list(/obj/item/ammo_box/magazine/misc/flares = 2)
 

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -88,7 +88,7 @@
 	var/flare_amount = 0
 	for(var/obj/item/storage/box/m94/flare_box in contents)
 		flare_amount += flare_box.contents.len
-	flare_amount = round(flare_amount / 8) //10 packs, 8 flares each, maximum total of 10 flares we can throw out
+	flare_amount = round(flare_amount / 20) //10 packs, 20 flares each, maximum total of 10 flares we can throw out
 	return flare_amount
 
 /obj/item/ammo_box/magazine/misc/flares/process_burning(datum/cause_data/flame_cause_data)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
makes it significantly easier to carry more flares
flare packs go from 8 to 21 
flare pouch goes from 8 to 21
flare gun belt goes from 17 to 27

adjusts flare box cookoff so that it doesn't spawn more flares than intended

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Currently flares are greatly underutilized, in PVP CM they're used to light up an area that marines are holding, or frontlines where marines are sticking around, this doesn't work very well in PvE CM, where marines are almost always on the move. Times where they're holding the area are rare and depend heavily on the objectives that a GM set, meaning that marines that take the flare pouch **EITHER** end up using their flares within the first 10~ minutes to light up the areas that they're moving through **OR** they save their flares, hoping that the GM has a "defense" portion of the objective so that they can get the full usage out of their flares.

By increasing the number of flares that can be held by marines, flare holders will be able to easily light up areas that they're passing through while still having flares to spare in case the marines need to hunker down for defense/triage.

Also I want to play as Scout DRG without running out of flares within 5 minutes of landing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing (link to discord because im lazy)</summary>

https://discord.com/channels/1160427683151368192/1164728861766975568/1202113175785312276

[download link:](https://cdn.discordapp.com/attachments/1165548715801579601/1202112129944256512/Flare_Buff_Demonstration.mp4?ex=65cc4529&is=65b9d029&hm=d1a107cf0cfe9003722647cb518e7cea9342602e67532bfba3dd226e1c6028c8&) 

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: GREATLY increased the number of flares that flare pouches, packs, and belts hold. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
