### PR TITLE
Adds Skullfaces to loadout options

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -161,6 +161,17 @@ var/global/list/gear_datums_by_name = list()
 	display_name = "USCM balaclava, tan"
 	path = /obj/item/clothing/mask/rebreather/scarf/tan
 
+/datum/gear/mask/uscm/skull_balaclava_blue
+	display_name = "USCM balaclava, blue skull"
+	path = /obj/item/clothing/mask/rebreather/skull
+	cost = 4 //same as skull facepaint
+
+/datum/gear/mask/uscm/skull_balaclava_black
+	display_name = "USCM balaclava, black skull"
+	path = /obj/item/clothing/mask/rebreather/skull/black
+	cost = 4
+
+
 /datum/gear/headwear
 	category = "Headwear"
 	cost = 3
@@ -875,6 +886,11 @@ var/global/list/gear_datums_by_name = list()
 /datum/gear/misc/facepaint_black
 	display_name = "Facepaint, black"
 	path = /obj/item/facepaint/black
+
+/datum/gear/misc/facepaint_skull
+	display_name = "Facepaint, skull"
+	path = /obj/item/facepaint/skull
+	cost = 3
 
 /datum/gear/misc/facepaint_body
 	display_name = "Fullbody paint"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

see title

# Explain why it's good for the game

readds the uscm skull faces to the loadout option, its been added to main CM with each reason outlined here
https://github.com/cmss13-devs/cmss13/pull/5042/files


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Skull Balaclavas and Facepaints return to loadout options 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
