### PR TITLE
rotates cryobeds on golden arrow the other (correct) way

### DIFF
--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -837,7 +837,9 @@
 	},
 /area/golden_arrow/medical)
 "eL" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/right{
+	dir = 2
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -1857,7 +1859,9 @@
 	},
 /area/golden_arrow/cryo_cells)
 "kr" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/right{
+	dir = 2
+	},
 /obj/structure/machinery/light{
 	dir = 4
 	},
@@ -2382,7 +2386,8 @@
 "nR" = (
 /obj/structure/machinery/cryopod{
 	layer = 3.1;
-	pixel_y = 13
+	pixel_y = 13;
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -2728,7 +2733,8 @@
 /area/golden_arrow/hangar)
 "qf" = (
 /obj/structure/machinery/cryopod/right{
-	pixel_y = 6
+	pixel_y = 6;
+	dir = 2
 	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -2750,7 +2756,8 @@
 "qm" = (
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
-	pixel_y = 13
+	pixel_y = 13;
+	dir = 2
 	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -2873,7 +2880,8 @@
 /area/golden_arrow/engineering)
 "rb" = (
 /obj/structure/machinery/cryopod{
-	pixel_y = 6
+	pixel_y = 6;
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -5769,7 +5777,9 @@
 /turf/open/floor/almayer,
 /area/golden_arrow/firingrange)
 "Ii" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -6503,6 +6513,14 @@
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "cargo_arrow"
+	},
+/area/golden_arrow/cryo_cells)
+"Mo" = (
+/obj/structure/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "cargo"
 	},
 /area/golden_arrow/cryo_cells)
 "Mu" = (
@@ -7383,7 +7401,9 @@
 	},
 /area/golden_arrow/platoon_sergeant)
 "QT" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod{
+	dir = 1
+	},
 /obj/structure/machinery/light{
 	dir = 8
 	},
@@ -20125,7 +20145,7 @@ HK
 Pf
 KP
 HK
-Ii
+Mo
 nR
 QT
 nR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

cryobeds were facing the wall and that looked kinda goofy 

# Explain why it's good for the game

no more goofy cryobdeds


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
maptweak: Rotated spawn cryobeds the other way.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
