### PR TITLE
adds crappy system for delayed/looping spawns

### DIFF
--- a/code/modules/admin/game_master/game_master.dm
+++ b/code/modules/admin/game_master/game_master.dm
@@ -218,7 +218,7 @@ GLOBAL_VAR_INIT(radio_communication_clarity, 100)
 
 		if("set_xeno_spawn_delay")
 			var/new_delay = text2num(params["value"])
-			if(!new_delay)
+			if(isnull(new_delay)) // obviously !new_delay won't work, because 0 is valid
 				return
 			// gotta set some kind of maximum
 			xeno_spawn_delay = round(clamp(new_delay, 0, 1 HOURS))

--- a/code/modules/admin/game_master/game_master_xeno_spawner.dm
+++ b/code/modules/admin/game_master/game_master_xeno_spawner.dm
@@ -1,0 +1,103 @@
+GLOBAL_LIST_EMPTY(gm_xeno_spawners)
+
+/datum/game_master_xeno_spawner
+	/// The actual image holder that is added to game masters' clients
+	var/image/gm_image
+
+	/// The location the xenomorphs will spawn at.
+	var/turf/spawn_loc
+
+	/// The type of xeno to be spawned.
+	var/mob/living/carbon/xenomorph/spawn_type
+
+	/// The number of xenos to be spawned.
+	var/spawn_count
+
+	/// The delay until xenos are spawned (may be 0, in which case xenos spawn instantaneously).
+	var/spawn_delay
+
+	/// If TRUE, the spawner will not delete itself after firing.
+	var/looping
+
+	/// The hive the spawned xenos will belong to.
+	var/spawn_hive
+
+	/// Whether or not to spawn xenos with AI: if TRUE, the spawned xenos will have AI.
+	var/spawn_ai
+
+	/// If TRUE, the spawn will fail if any humans are within "fail_range" tiles.
+	/// This will cause the spawner to either delete itself or reset its spawn timer, depending on whether it loops.
+	var/fail_if_human_near
+
+	var/fail_range = 9
+
+/datum/game_master_xeno_spawner/New(turf/s_loc, mob/living/carbon/xenomorph/s_type, s_count, s_delay, loop, s_hive, s_ai, fail_human)
+	GLOB.gm_xeno_spawners += src
+
+	spawn_loc = s_loc
+	spawn_type = s_type
+	spawn_count = s_count
+	spawn_delay = s_delay
+	looping = loop
+	spawn_hive = s_hive
+	spawn_ai = s_ai
+	fail_if_human_near = fail_human
+
+	// we can return early if we aren't waiting for anything
+	if(spawn_delay <= 0)
+		spawn_xenos()
+		return
+
+	addtimer(CALLBACK(src, PROC_REF(spawn_xenos)), spawn_delay)
+
+	// get the icon state for the xeno type we're trying to spawn
+	var/derived_icon_state =  initial(spawn_type.mutation_type) + " " + initial(spawn_type.icon_state)
+	gm_image = new(
+		initial(spawn_type.icon),
+		spawn_loc,
+		derived_icon_state,
+		layer = ABOVE_FLY_LAYER,
+	)
+	// centers the xeno
+	gm_image.pixel_x = -(initial(spawn_type.icon_size) - 32)/2
+	// slightly more visible than observers
+	gm_image.alpha = 150
+	// color matrix. this makes them look sorta overexposed. janky, but it's more important that it looks distinguishable than good
+	gm_image.color = list(
+		1.5, 0, 0,
+		0, 1.5, 0,
+		0, 0, 1.5,
+		0.25, 0.25, 0.25
+	)
+
+	for(var/client/game_master in GLOB.game_masters)
+		game_master.images |= gm_image
+
+/datum/game_master_xeno_spawner/Destroy(force, silent, ...)
+	. = ..()
+
+	GLOB.gm_xeno_spawners -= src
+
+	// cleans up the image
+	if(gm_image)
+		for(var/client/game_master in GLOB.game_masters)
+			game_master.images -= gm_image
+		QDEL_NULL(gm_image)
+
+/datum/game_master_xeno_spawner/proc/spawn_xenos()
+	var/failure = FALSE
+
+	if(fail_if_human_near)
+		for(var/mob/living/carbon/human as anything in GLOB.alive_human_list)
+			if(human.client && human.z == spawn_loc.z && (get_dist(human, spawn_loc) <= fail_range))
+				failure = TRUE
+				break
+
+	if(!failure)
+		for(var/i = 1 to spawn_count)
+			new spawn_type(spawn_loc, null, spawn_hive, !spawn_ai)
+
+	if(spawn_delay && looping)
+		addtimer(CALLBACK(src, PROC_REF(spawn_xenos)), spawn_delay)
+	else
+		qdel(src)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -1385,6 +1385,7 @@
 #include "code\modules\admin\ToRban.dm"
 #include "code\modules\admin\game_master\game_master.dm"
 #include "code\modules\admin\game_master\game_master_submenu.dm"
+#include "code\modules\admin\game_master\game_master_xeno_spawner.dm"
 #include "code\modules\admin\game_master\extra_buttons\rappel_menu.dm"
 #include "code\modules\admin\game_master\extra_buttons\rename_platoon.dm"
 #include "code\modules\admin\game_master\extra_buttons\toggle_join_xeno.dm"

--- a/tgui/packages/tgui/interfaces/GameMaster.js
+++ b/tgui/packages/tgui/interfaces/GameMaster.js
@@ -6,7 +6,7 @@ export const GameMaster = (props, context) => {
   const { data, act } = useBackend(context);
 
   return (
-    <Window width={400} height={500}>
+    <Window width={650} height={500}>
       <Window.Content scrollable>
         <Stack direction="column" grow>
           <GameMasterSpawningPanel />
@@ -65,6 +65,41 @@ export const GameMasterSpawningPanel = (props, context) => {
         </Stack.Item>
         <Stack.Item>
           <Stack>
+            <Stack.Item>Delay (s)</Stack.Item>
+            <Stack.Item>
+              <Button.Input
+                ml={1}
+                minWidth={6}
+                minHeight={1.5}
+                content={data.xeno_spawn_delay}
+                currentValue={data.xeno_spawn_delay}
+                onCommit={(e, value) => {
+                  act('set_xeno_spawn_delay', { value });
+                }}
+              />
+            </Stack.Item>
+            <Stack.Item>
+              <Button.Checkbox
+                checked={data.xeno_spawn_looping}
+                content="Looping"
+                onClick={() => {
+                  act('xeno_spawn_looping_toggle');
+                }}
+              />
+            </Stack.Item>
+            <Stack.Item>
+              <Button.Checkbox
+                checked={data.xeno_spawn_fail_human}
+                content="Fail spawn if humans nearby"
+                onClick={() => {
+                  act('xeno_spawn_fail_human_toggle');
+                }}
+              />
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item>
+          <Stack>
             <Stack.Item>
               <Button.Checkbox
                 checked={data.spawn_ai}
@@ -105,6 +140,57 @@ export const GameMasterSpawningPanel = (props, context) => {
             </Stack.Item>
           </Stack>
         </Stack.Item>
+        {data.xeno_spawners && (
+          <Stack.Item>
+            <Collapsible title="Spawners">
+              <Stack vertical>
+                {data.xeno_spawners.map((spawner) => {
+                  if (spawner) {
+                    let spawner_ref = spawner.ref;
+                    return (
+                      <Stack.Item>
+                        <Stack direction="column">
+                          <Divider />
+                          <Stack.Item>Caste: {spawner.spawn_type}</Stack.Item>
+                          <Stack.Item>Count: {spawner.spawn_count}</Stack.Item>
+                          <Stack.Item>Delay: {spawner.spawn_delay}s</Stack.Item>
+                          <Stack.Item>
+                            Looping: {spawner.looping ? 'True' : 'False'}
+                          </Stack.Item>
+                          <Stack.Item>
+                            Fail if human within {spawner.fail_range}:{' '}
+                            {spawner.fail_human ? 'True' : 'False'}
+                          </Stack.Item>
+                          <Stack.Item>
+                            <Stack vertical>
+                              <Stack.Item>
+                                <Button
+                                  content="Jump To"
+                                  onClick={() => {
+                                    act('jump_to_spawner', { spawner_ref });
+                                  }}
+                                />
+                              </Stack.Item>
+                              <Stack.Item>
+                                <Button
+                                  content="Delete"
+                                  onClick={() => {
+                                    act('delete_spawner', { spawner_ref });
+                                  }}
+                                />
+                              </Stack.Item>
+                            </Stack>
+                          </Stack.Item>
+                        </Stack>
+                      </Stack.Item>
+                    );
+                  }
+                })}
+                <Divider />
+              </Stack>
+            </Collapsible>
+          </Stack.Item>
+        )}
       </Stack>
     </Section>
   );


### PR DESCRIPTION
# About the pull request

Adds buttons to the GM panel allowing for xenomorph spawns to be delayed by up to 1 hour, "looped" so that they repeat on the same delay, and hidden from players by failing if any living, connected humans are found within 9 tiles (this effect applies for non-delayed spawns as well, if the toggle is pressed). These spawns can then be teleported to or deleted remotely via the panel.

the approach here is sort of crappy, but i'm not sure whether /obj/effect s are as ubiquitous here for effects like these as they are on other codebases, or how to make effects visible to GMs only. 

# Explain why it's good for the game

Makes it easier for GMs to juggle multiple things at once by letting them set up spawns in advance, while preventing those spawns from breaking the fourth wall.

# Testing Photographs and Procedure
<details>

i tested it well enough. didnt take screenshots and i am currently very tired

</details>

# Changelog

:cl:
add: Added delayed, looped, and "hidden" xenomorph spawns for GMs.
/:cl:
