### PR TITLE
MK1 Mag Boxes and 10x28mm ammo cans

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -280,6 +280,8 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 		new/datum/stack_recipe("empty rifle ammo box (10x24mm Incen)", /obj/item/ammo_box/rounds/incen/empty), \
 		new/datum/stack_recipe("empty rifle ammo box (10x24mm LE)", /obj/item/ammo_box/rounds/le/empty), \
 		null, \
+		new/datum/stack_recipe("empty rifle ammo box (10x28mm)", /obj/item/ammo_box/rounds/smartgun/empty), \
+		null, \
 		new/datum/stack_recipe("empty box of MREs", /obj/item/ammo_box/magazine/misc/mre/empty), \
 		new/datum/stack_recipe("empty box of M94 Marking Flare Packs", /obj/item/ammo_box/magazine/misc/flares/empty), \
 		new/datum/stack_recipe("empty box of flashlights", /obj/item/ammo_box/magazine/misc/flashlight/empty), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -280,7 +280,7 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 		new/datum/stack_recipe("empty rifle ammo box (10x24mm Incen)", /obj/item/ammo_box/rounds/incen/empty), \
 		new/datum/stack_recipe("empty rifle ammo box (10x24mm LE)", /obj/item/ammo_box/rounds/le/empty), \
 		null, \
-		new/datum/stack_recipe("empty rifle ammo box (10x28mm)", /obj/item/ammo_box/rounds/smartgun/empty), \
+		new/datum/stack_recipe("empty smartgun ammo box (10x28mm)", /obj/item/ammo_box/rounds/smartgun/empty), \
 		null, \
 		new/datum/stack_recipe("empty box of MREs", /obj/item/ammo_box/magazine/misc/mre/empty), \
 		new/datum/stack_recipe("empty box of M94 Marking Flare Packs", /obj/item/ammo_box/magazine/misc/flares/empty), \

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -60,6 +60,17 @@
 /obj/item/ammo_box/magazine/heap/empty
 	empty = TRUE
 
+	
+/obj/item/ammo_box/magazine/mk1
+	name = "magazine box (M41A MK1 X 10)"
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = "_reg"
+	overlay_content = "_reg"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1
+
+/obj/item/ammo_box/magazine/mk1/empty
+	empty = TRUE
+
 //-----------------------M39 Rifle Mag Boxes-----------------------
 
 /obj/item/ammo_box/magazine/m39

--- a/code/modules/projectiles/ammo_boxes/round_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/round_boxes.dm
@@ -40,6 +40,19 @@
 /obj/item/ammo_box/rounds/heap/empty
 	empty = TRUE
 
+//----------------10x28mm Ammunition Boxes (for smartguns)------------------
+
+/obj/item/ammo_box/rounds/smartgun
+	name = "\improper rifle ammunition box (10x28mm)"
+	desc = "A 10x28mm ammunition box. Used to refill smartgun drum magazines. It comes with a leather strap allowing to wear it on the back."
+	overlay_content = "_reg"
+	default_ammo = /datum/ammo/bullet/smartgun
+	caliber = "10x28mm"
+	max_bullet_amount = 1000
+
+/obj/item/ammo_box/rounds/smartgun/empty
+	empty = TRUE
+
 //----------------10x20mm Ammunition Boxes (for M39 SMG)------------------
 
 /obj/item/ammo_box/rounds/smg

--- a/code/modules/projectiles/ammo_boxes/round_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/round_boxes.dm
@@ -43,7 +43,7 @@
 //----------------10x28mm Ammunition Boxes (for smartguns)------------------
 
 /obj/item/ammo_box/rounds/smartgun
-	name = "\improper rifle ammunition box (10x28mm)"
+	name = "\improper smartgun ammunition box (10x28mm)"
 	desc = "A 10x28mm ammunition box. Used to refill smartgun drum magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_reg"
 	default_ammo = /datum/ammo/bullet/smartgun


### PR DESCRIPTION
For some reason, these items were both missing from base CM code. This allows empty ammo cans for 10x28mm (smartgun ammo) to be crafted from cardboard and an empty mag box for MK1 magazines which will be a massive quality of life increase as our ammo just sits on the dropship to be flamed. This should theoretically make life even the slightest bit easier for GMs when it comes to resupplying platoons in round as well. MK1 boxes have been requested a few times from the community.