### PR TITLE
Adds M48A4 to the character creation loadout

### DIFF
--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -133,6 +133,24 @@
 	max_w_class = SIZE_MEDIUM
 	storage_slots = 3
 
+/obj/item/storage/box/M48A4_loadout
+	name = "M48A4 storage case"
+	desc = "A relatively large storage case containing the M48A4 and magazines. Purchased by enlisted or aspiring PMCs looking to carry a timeless classic"
+	icon = 'icons/obj/items/storage.dmi'
+	icon_state = "guncase"
+	w_class = SIZE_MEDIUM
+	max_w_class = SIZE_MEDIUM
+	storage_slots = 7
+
+/obj/item/storage/box/M48A4_loadout/fill_preset_inventory()
+	new /obj/item/weapon/gun/pistol/m1911/socom(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+
 /obj/item/storage/box/upp/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/t73(src)
 	new /obj/item/ammo_magazine/pistol/t73(src)

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -133,21 +133,17 @@
 	max_w_class = SIZE_MEDIUM
 	storage_slots = 3
 
-/obj/item/storage/box/M48A4_loadout
-	name = "M48A4 storage case"
-	desc = "A relatively large storage case containing the M48A4 and magazines. Purchased by enlisted or aspiring PMCs looking to carry a timeless classic"
+/obj/item/storage/box/M1911_loadout
+	name = "M1911 storage case"
+	desc = "A relatively large storage case containing the 1911 and additional magazines. Purchased by enlisted or aspiring PMCs looking to carry a timeless classic"
 	icon = 'icons/obj/items/storage.dmi'
-	icon_state = "guncase"
+	icon_state = "matebacase"
 	w_class = SIZE_MEDIUM
 	max_w_class = SIZE_MEDIUM
-	storage_slots = 7
+	storage_slots = 3
 
-/obj/item/storage/box/M48A4_loadout/fill_preset_inventory()
-	new /obj/item/weapon/gun/pistol/m1911/socom(src)
-	new /obj/item/ammo_magazine/pistol/m1911(src)
-	new /obj/item/ammo_magazine/pistol/m1911(src)
-	new /obj/item/ammo_magazine/pistol/m1911(src)
-	new /obj/item/ammo_magazine/pistol/m1911(src)
+/obj/item/storage/box/M1911_loadout/fill_preset_inventory()
+	new /obj/item/weapon/gun/pistol/m1911(src)
 	new /obj/item/ammo_magazine/pistol/m1911(src)
 	new /obj/item/ammo_magazine/pistol/m1911(src)
 

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -623,6 +623,11 @@ var/global/list/gear_datums_by_name = list()
 	path = /obj/item/weapon/gun/revolver/m44/custom
 	allowed_origins = USCM_ORIGINS
 
+/datum/gear/weapon/m48a4
+	display_name = "M48A4 Service Pistol"
+	path = /obj/item/storage/box/M48A4_loadout
+	allowed_origins = USCM_ORIGINS
+
 /datum/gear/drink
 	category = "Canned drinks"
 

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -623,9 +623,9 @@ var/global/list/gear_datums_by_name = list()
 	path = /obj/item/weapon/gun/revolver/m44/custom
 	allowed_origins = USCM_ORIGINS
 
-/datum/gear/weapon/m48a4
-	display_name = "M48A4 Service Pistol"
-	path = /obj/item/storage/box/M48A4_loadout
+/datum/gear/weapon/m1911
+	display_name = "M1911 Service Pistol"
+	path = /obj/item/storage/box/M1911_loadout
 	allowed_origins = USCM_ORIGINS
 
 /datum/gear/drink


### PR DESCRIPTION

# About the pull request

Pretty self explanatory, M48A4 is now in the character creation pointbuy

# Explain why it's good for the game

Muh two world wars! and i just think its neat. Allows a little more character to the marines choice of sidearms. +

# Changelog

<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Merrgear2
add: Adds the M48A4 Service Pistol to the loadout pointbuy
:cl: 

<!-- Both :cl:'s are required for the changelog to work! -->
