### PR TITLE
fixes corpsman's icon in squad info

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -279,7 +279,7 @@
 		list("Mar", null),
 		list("ass", "hudsquad_ass"),
 		list("Eng", "hudsquad_engi"),
-		list("Med", "hudsquad_med"),
+		list("HM", "hudsquad_med"),
 		list("SG", "hudsquad_gun"),
 		list("Spc", "hudsquad_spec"),
 		list("SqSgt", "hudsquad_tl"),


### PR DESCRIPTION
no more gray square
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/44546836/b7beca4d-133e-4f03-841b-e72180e3aee4)
