### PR TITLE
Janitorial buckets are for janitorial duty, not corpsmen

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -640,7 +640,8 @@
 	name = "janitorial bucket"
 	desc = "It's a large bucket that fits in a janitorial cart. Holds 500 units."
 	icon_state = "janibucket"
-	matter = list("metal" = 8000)
+	matter = list("metal" = 8000)	
+	w_class = SIZE_LARGE
 	volume = 500
 
 


### PR DESCRIPTION
Janitorial buckets currently fit in drop pouches, backpacks, satchels and more which defies logic. This has the side effect of completely breaking the load-carriage economy by letting someone effortlessly carry up to 1000u of medical mixtures for almost free, seeing as there are two buckets aboard the Arrow. 