### PR TITLE
Prime Priority Rolls for Discord Linked Players

### DIFF
--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -469,6 +469,7 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 	set waitfor=0
 	WAIT_DB_READY
 	load_player_data_info(get_player_from_key(ckey))
+	check_discord_link()
 
 /client/proc/load_player_data_info(datum/entity/player/player)
 	if(ckey != player.ckey)
@@ -480,6 +481,25 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 	player_data.last_known_cid = computer_id
 	player_data.save()
 	record_login_triplet(player.ckey, address, computer_id)
+	player_data.sync()
+
+/client/proc/check_discord_link()
+	var/datum/view_record/discord_link/current_link = locate() in DB_VIEW(/datum/view_record/discord_link, DB_COMP("player_id", DB_EQUALS, player_data.id))
+
+	if(!current_link)
+
+		if(player_data.discord_link_id != null)
+			player_data.discord_link_id = null
+			player_data.save()
+			player_data.sync()
+
+		return
+
+	if(player_data.discord_link_id == current_link.id)
+		return
+
+	player_data.discord_link_id = current_link.id
+	player_data.save()
 	player_data.sync()
 
 /datum/entity/player/proc/check_ban(computer_id, address, is_telemetry)

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -52,6 +52,7 @@ AddTimelock(/datum/job/command/bridge, list(
 /datum/job/command/bridge/ai
 	total_positions = 1
 	spawn_positions = 1
+	prime_priorty = TRUE
 
 /datum/job/command/bridge/ai/set_spawn_positions(count)
 	return spawn_positions

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -52,7 +52,7 @@ AddTimelock(/datum/job/command/bridge, list(
 /datum/job/command/bridge/ai
 	total_positions = 1
 	spawn_positions = 1
-	prime_priorty = TRUE
+	prime_priority = TRUE
 
 /datum/job/command/bridge/ai/set_spawn_positions(count)
 	return spawn_positions

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -41,6 +41,9 @@
 	/// If TRUE, this job will spawn w/ a cryo emergency kit during evac/red alert
 	var/gets_emergency_kit = TRUE
 
+	/// Whether or not linking your discord account can let you get prime priority for this role
+	var/prime_priority = FALSE
+
 /datum/job/New()
 	. = ..()
 

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -53,6 +53,7 @@ AddTimelock(/datum/job/marine/leader, list(
 /datum/job/marine/leader/ai
 	total_positions = 1
 	spawn_positions = 1
+	prime_priority = TRUE
 
 /datum/job/marine/leader/ai/upp
 	title = JOB_SQUAD_LEADER_UPP

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -18,9 +18,10 @@ var/global/datum/authority/branch/role/RoleAuthority
 #define RETURN_TO_LOBBY 2
 
 #define NEVER_PRIORITY 0
-#define HIGH_PRIORITY 1
-#define MED_PRIORITY 2
-#define LOW_PRIORITY 3
+#define PRIME_PRIORITY 1
+#define HIGH_PRIORITY 2
+#define MED_PRIORITY 3
+#define LOW_PRIORITY 4
 
 #define SHIPSIDE_ROLE_WEIGHT 0.25
 
@@ -244,6 +245,10 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 /datum/authority/branch/role/proc/assign_roles(list/roles_to_assign, list/unassigned_players)
 	if(!length(roles_to_assign) || !length(unassigned_players))
 		return
+
+	//for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
+	//	var/wanted_jobs_by_name = shuffle(cycled_unassigned.client?.prefs?.get_jobs_by_priority(PRIME_PRIORITY))
+	// Set up prime priority first rolls, probably put line 257 in a new function and then pass priority through manually - Morrow
 
 	for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
 		var/player_assigned_job = FALSE

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -256,6 +256,8 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 		for(var/priority in HIGH_PRIORITY to LOW_PRIORITY)
 			player_assigned_job = assign_role_to_player_by_priority(cycled_unassigned, roles_to_assign, unassigned_players, priority)
+			if(player_assigned_job)
+				break
 
 		if(!length(roles_to_assign))
 			log_debug("ASSIGNMENT: No more roles to assign, breaking.")

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -246,40 +246,16 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	if(!length(roles_to_assign) || !length(unassigned_players))
 		return
 
-	//for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
-	//	var/wanted_jobs_by_name = shuffle(cycled_unassigned.client?.prefs?.get_jobs_by_priority(PRIME_PRIORITY))
-	// Set up prime priority first rolls, probably put line 257 in a new function and then pass priority through manually - Morrow
+	log_debug("ASSIGNMENT: Starting prime priority assignments.")
+	for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
+		assign_role_to_player_by_priority(cycled_unassigned, roles_to_assign, unassigned_players, PRIME_PRIORITY)
 
+	log_debug("ASSIGNMENT: Starting regular priority assignments.")
 	for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
 		var/player_assigned_job = FALSE
-		log_debug("ASSIGNMENT: We have started assigning for [cycled_unassigned].")
 
 		for(var/priority in HIGH_PRIORITY to LOW_PRIORITY)
-			var/wanted_jobs_by_name = shuffle(cycled_unassigned.client?.prefs?.get_jobs_by_priority(priority))
-			log_debug("ASSIGNMENT: We have started cycled through priority [priority] for [cycled_unassigned].")
-
-			for(var/job_name in wanted_jobs_by_name)
-				log_debug("ASSIGNMENT: We are cycling through wanted jobs and are at [job_name] for [cycled_unassigned].")
-				if(job_name in roles_to_assign)
-					log_debug("ASSIGNMENT: We have found [job_name] in roles to assign for [cycled_unassigned].")
-					var/datum/job/actual_job = roles_to_assign[job_name]
-
-					if(assign_role(cycled_unassigned, actual_job))
-						log_debug("ASSIGNMENT: We have assigned [job_name] to [cycled_unassigned].")
-						unassigned_players -= cycled_unassigned
-
-						if(actual_job.spawn_positions != -1 && actual_job.current_positions >= actual_job.spawn_positions)
-							roles_to_assign -= job_name
-							log_debug("ASSIGNMENT: We have ran out of slots for [job_name] and it has been removed from roles to assign.")
-
-						player_assigned_job = TRUE
-						break
-
-			if(player_assigned_job)
-				log_debug("ASSIGNMENT: [cycled_unassigned] has been assigned a job and we are breaking.")
-				break
-
-			log_debug("ASSIGNMENT: [cycled_unassigned] did not get a job at priority [priority], moving to next priority level.")
+			player_assigned_job = assign_role_to_player_by_priority(cycled_unassigned, roles_to_assign, unassigned_players, priority)
 
 		if(!length(roles_to_assign))
 			log_debug("ASSIGNMENT: No more roles to assign, breaking.")
@@ -326,9 +302,38 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 					log_debug("ASSIGNMENT: [cycled_unassigned] has opted for return to lobby alternate option.")
 					cycled_unassigned.ready = 0
 
-	log_debug("ASSIGNMENT: Assigning complete. Players unassigned: [length(unassigned_players)] Jobs unassigned: [length(roles_to_assign)]")
+	log_debug("ASSIGNMENT: Assignment complete. Players unassigned: [length(unassigned_players)] Jobs unassigned: [length(roles_to_assign)]")
 
 	return roles_to_assign
+
+/datum/authority/branch/role/proc/assign_role_to_player_by_priority(mob/new_player/cycled_unassigned, list/roles_to_assign, list/unassigned_players, priority)
+	log_debug("ASSIGNMENT: We have started cycled through priority [priority] for [cycled_unassigned].")
+	var/wanted_jobs_by_name = shuffle(cycled_unassigned.client?.prefs?.get_jobs_by_priority(priority))
+	var/player_assigned_job = FALSE
+
+	for(var/job_name in wanted_jobs_by_name)
+		log_debug("ASSIGNMENT: We are cycling through wanted jobs and are at [job_name] for [cycled_unassigned].")
+		if(job_name in roles_to_assign)
+			log_debug("ASSIGNMENT: We have found [job_name] in roles to assign for [cycled_unassigned].")
+			var/datum/job/actual_job = roles_to_assign[job_name]
+
+			if(assign_role(cycled_unassigned, actual_job))
+				log_debug("ASSIGNMENT: We have assigned [job_name] to [cycled_unassigned].")
+				unassigned_players -= cycled_unassigned
+
+				if(actual_job.spawn_positions != -1 && actual_job.current_positions >= actual_job.spawn_positions)
+					roles_to_assign -= job_name
+					log_debug("ASSIGNMENT: We have ran out of slots for [job_name] and it has been removed from roles to assign.")
+
+				player_assigned_job = TRUE
+				break
+
+	if(player_assigned_job)
+		log_debug("ASSIGNMENT: [cycled_unassigned] has been assigned a job.")
+		return player_assigned_job
+
+	log_debug("ASSIGNMENT: [cycled_unassigned] did not get a job at priority [priority].")
+	return player_assigned_job
 
 /**
 * Calculate role balance weight for one person joining as that role. This weight is used

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -648,7 +648,7 @@ var/const/MAX_SAVE_SLOTS = 10
 //splitJobs - Allows you split the table by job. You can make different tables for each department by including their heads. Defaults to CE to make it look nice.
 //width - Screen' width.
 //height - Screen's height.
-/datum/preferences/proc/SetChoices(mob/user, limit = 19, list/splitJobs = list(JOB_CHIEF_REQUISITION), width = 450, height = 450)
+/datum/preferences/proc/SetChoices(mob/user, limit = 19, list/splitJobs = list(JOB_CHIEF_REQUISITION), width = 480, height = 450)
 	if(!RoleAuthority)
 		return
 
@@ -680,7 +680,7 @@ var/const/MAX_SAVE_SLOTS = 10
 			HTML += "</table></td><td valign='top' width='20%'><table width='100%' cellpadding='1' cellspacing='0'>"
 			index = 0
 
-		HTML += "<tr class='[job.selection_class]'><td width='40%' align='right'>"
+		HTML += "<tr class='[job.selection_class]'><td width='30%' align='center'>"
 
 		if(jobban_isbanned(user, job.title))
 			HTML += "<b><del>[job.disp_title]</del></b></td><td width='10%' align='center'></td><td><b>BANNED</b></td></tr>"
@@ -731,7 +731,7 @@ var/const/MAX_SAVE_SLOTS = 10
 					b_color = "orange"
 					priority_text = "LOW"
 
-			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_priority || !user.client?.player_data?.discord_link_id))
+			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_priority || !user.client?.player_data?.discord_link_id || user.client?.get_total_human_playtime() < JOB_PLAYTIME_TIER_1))
 				continue
 
 			HTML += "<a class='[j == cur_priority ? b_color : "inactive"]' href='?_src_=prefs;preference=job;task=input;text=[job.title];target_priority=[j];'>[priority_text]</a>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -731,7 +731,7 @@ var/const/MAX_SAVE_SLOTS = 10
 					b_color = "orange"
 					priority_text = "LOW"
 
-			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_option || !user.client?.player_data?.discord_link_id))
+			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_priority || !user.client?.player_data?.discord_link_id))
 				continue
 
 			HTML += "<a class='[j == cur_priority ? b_color : "inactive"]' href='?_src_=prefs;preference=job;task=input;text=[job.title];target_priority=[j];'>[priority_text]</a>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -652,6 +652,10 @@ var/const/MAX_SAVE_SLOTS = 10
 	if(!RoleAuthority)
 		return
 
+	var/host_bypass = FALSE
+	if(user.client?.admin_holder?.check_for_rights(R_HOST))
+		host_bypass = TRUE
+
 	var/HTML = "<body>"
 	HTML += "<tt><center>"
 	HTML += "<b>Choose occupation chances</b><br>Unavailable occupations are crossed out.<br><br>"
@@ -714,6 +718,9 @@ var/const/MAX_SAVE_SLOTS = 10
 				if(NEVER_PRIORITY)
 					b_color = "red"
 					priority_text = "NEVER"
+				if(PRIME_PRIORITY)
+					b_color = "purple"
+					priority_text = "PRIME"
 				if(HIGH_PRIORITY)
 					b_color = "blue"
 					priority_text = "HIGH"
@@ -723,6 +730,9 @@ var/const/MAX_SAVE_SLOTS = 10
 				if(LOW_PRIORITY)
 					b_color = "orange"
 					priority_text = "LOW"
+
+			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_option || !user.client?.player_data?.discord_link_id))
+				continue
 
 			HTML += "<a class='[j == cur_priority ? b_color : "inactive"]' href='?_src_=prefs;preference=job;task=input;text=[job.title];target_priority=[j];'>[priority_text]</a>"
 			if (j < 4)
@@ -922,11 +932,15 @@ var/const/MAX_SAVE_SLOTS = 10
 	if(!J || priority < 0 || priority > 4)
 		return FALSE
 
-
 	if(!length(job_preference_list))
 		ResetJobs()
 
 	// Need to set old HIGH priority to 2
+	if(priority == PRIME_PRIORITY)
+		for(var/job in job_preference_list)
+			if(job_preference_list[job] == PRIME_PRIORITY)
+				job_preference_list[job] = MED_PRIORITY
+
 	if(priority == HIGH_PRIORITY)
 		for(var/job in job_preference_list)
 			if(job_preference_list[job] == HIGH_PRIORITY)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN 8
-#define SAVEFILE_VERSION_MAX 23
+#define SAVEFILE_VERSION_MAX 24
 
 //handles converting savefiles to new formats
 //MAKE SURE YOU KEEP THIS UP TO DATE!
@@ -96,9 +96,19 @@
 			temp_ooccolor = "#1c52f5"
 		S["ooccolor"] << temp_ooccolor
 
-	if(savefile_version < 23)
-		var/overwrite_job_preference_list = list()
-		S["job_preference_list"] << overwrite_job_preference_list
+	/// Skipping 23 due to a woopsy with job resets
+	if(savefile_version < 24)
+		for(var/i in 1 to 10)
+			S.cd = "/character[i]"
+			var/overwrite_job_preference_list
+			S["job_preference_list"] >> overwrite_job_preference_list
+
+			for(var/j in overwrite_job_preference_list)
+				overwrite_job_preference_list[j] = 0
+
+			S["job_preference_list"] << overwrite_job_preference_list
+
+		S.cd = "/"
 
 	savefile_version = SAVEFILE_VERSION_MAX
 	return 1

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN 8
-#define SAVEFILE_VERSION_MAX 22
+#define SAVEFILE_VERSION_MAX 23
 
 //handles converting savefiles to new formats
 //MAKE SURE YOU KEEP THIS UP TO DATE!
@@ -95,6 +95,10 @@
 		if(temp_ooccolor == "#b82e00")
 			temp_ooccolor = "#1c52f5"
 		S["ooccolor"] << temp_ooccolor
+
+	if(savefile_version < 23)
+		var/overwrite_job_preference_list = list()
+		S["job_preference_list"] << overwrite_job_preference_list
 
 	savefile_version = SAVEFILE_VERSION_MAX
 	return 1
@@ -574,7 +578,7 @@
 		ResetJobs()
 	else
 		for(var/job in job_preference_list)
-			job_preference_list[job] = sanitize_integer(job_preference_list[job], 0, 3, initial(job_preference_list[job]))
+			job_preference_list[job] = sanitize_integer(job_preference_list[job], 0, 4, initial(job_preference_list[job]))
 
 	if(!organ_data)
 		organ_data = list()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -216,12 +216,16 @@
 		rotate_right.screen_loc = "preview:1:-16,0"
 
 /datum/preferences/proc/job_pref_to_gear_preset()
-	var/high_priority
+	var/highest_priority
 	for(var/job in job_preference_list)
-		if(job_preference_list[job] == 1)
-			high_priority = job
+		if(job_preference_list[job] == HIGH_PRIORITY)
+			highest_priority = job
 
-	switch(high_priority)
+		if(job_preference_list[job] == PRIME_PRIORITY)
+			highest_priority = job
+			break
+
+	switch(highest_priority)
 		if(JOB_SQUAD_MARINE)
 			return /datum/equipment_preset/uscm/private_equipped
 		if(JOB_SQUAD_ENGI)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -216,16 +216,17 @@
 		rotate_right.screen_loc = "preview:1:-16,0"
 
 /datum/preferences/proc/job_pref_to_gear_preset()
-	var/highest_priority
+	var/highest_priority_job
+	var/highest_priority = LOW_PRIORITY
+
 	for(var/job in job_preference_list)
-		if(job_preference_list[job] == HIGH_PRIORITY)
-			highest_priority = job
+		if(job_preference_list[job] == NEVER_PRIORITY)
+			continue
 
-		if(job_preference_list[job] == PRIME_PRIORITY)
-			highest_priority = job
-			break
+		if(job_preference_list[job] < highest_priority)
+			highest_priority_job = job
 
-	switch(highest_priority)
+	switch(highest_priority_job)
 		if(JOB_SQUAD_MARINE)
 			return /datum/equipment_preset/uscm/private_equipped
 		if(JOB_SQUAD_ENGI)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -225,6 +225,7 @@
 
 		if(job_preference_list[job] < highest_priority)
 			highest_priority_job = job
+			highest_priority = job_preference_list[job]
 
 	switch(highest_priority_job)
 		if(JOB_SQUAD_MARINE)


### PR DESCRIPTION
Adds support for a new priority level that rolls before other priorities.

It is accessible for only PltCo/PltSgt and you must have more than 10 hours in game and linked your discord via the bot on the discord.

This should help push the players who are getting important rules are active in the community and have at least some experience.