### PR TITLE
AI tweaks and fixes

### DIFF
--- a/code/__DEFINES/xeno_ai.dm
+++ b/code/__DEFINES/xeno_ai.dm
@@ -7,15 +7,15 @@
 
 #define OPEN_TURF_PENALTY 1
 #define DOOR_PENALTY 3
-#define OBJECT_PENALTY 20
 #define HUMAN_PENALTY 4
 #define XENO_PENALTY 20
-#define VEHICLE_PENALTY 25
+#define OBJECT_PENALTY 20
+#define FIRE_PENALTY 25
 #define SENTRY_PENALTY 25
+#define VEHICLE_PENALTY 25
 #define WINDOW_FRAME_PENALTY 25
 #define BARRICADE_PENALTY 50
 #define WALL_PENALTY 50
-#define FIRE_PENALTY 25
 
 /*
 PROBABILITY CALCULATIONS ARE HERE
@@ -90,7 +90,7 @@ PROBABILITY CALCULATIONS ARE HERE
 
 
 /// Special blockers for pathfinding or obstacle handling
-#define XENO_AI_SPECIAL_BLOCKERS list(/obj/flamer_fire, /obj/vehicle/multitile, /turf/open/space)
+#define XENO_AI_SPECIAL_BLOCKERS list(/obj/flamer_fire, /obj/vehicle/multitile, /turf/open/space, /turf/open/gm/river)
 
 // Friend-or-foe universal check
 #define IS_SAME_HIVENUMBER(A,B) (A.hivenumber == B.hivenumber)

--- a/code/controllers/subsystem/pathfinding.dm
+++ b/code/controllers/subsystem/pathfinding.dm
@@ -129,10 +129,11 @@ SUBSYSTEM_DEF(xeno_pathfinding)
 /datum/controller/subsystem/xeno_pathfinding/proc/check_special_blockers(mob/living/carbon/xenomorph/xeno, turf/checking_turf)
 	var/list/pass_back = list()
 
-	pass_back += (checking_turf.type in XENO_AI_SPECIAL_BLOCKERS) ? checking_turf : list()
+	for(var/spec_blocker in XENO_AI_SPECIAL_BLOCKERS)
+		pass_back += istype(checking_turf, spec_blocker) ? checking_turf : list()
 
-	for(var/atom/checked_atom as anything in checking_turf)
-		pass_back += (checked_atom.type in XENO_AI_SPECIAL_BLOCKERS) ? checked_atom : list()
+		for(var/atom/checked_atom as anything in checking_turf)
+			pass_back += istype(checked_atom, spec_blocker) ? checked_atom : list()
 
 	return pass_back
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -7,7 +7,6 @@
 	var/base_icon_state = "pdoor"
 	id = 1
 	dir = NORTH
-	unslashable = TRUE
 	health = 0
 	layer = PODDOOR_CLOSED_LAYER
 	open_layer = PODDOOR_OPEN_LAYER
@@ -253,13 +252,11 @@
 	name = ""
 	icon = null
 	icon_state = ""
-	unslashable = TRUE
 	unacidable = TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/four_tile/secure
 	icon = 'icons/obj/structures/doors/1x4blast_hor_secure.dmi'
 	openspeed = 17
-	unslashable = TRUE
 	unacidable = TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/four_tile/secure/opened
@@ -268,7 +265,6 @@
 /obj/structure/machinery/door/poddoor/two_tile/four_tile/vertical/secure
 	icon = 'icons/obj/structures/doors/1x4blast_vert_secure.dmi'
 	openspeed = 17
-	unslashable = TRUE
 	unacidable = TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/four_tile/vertical/secure/open
@@ -286,7 +282,6 @@
 /obj/structure/machinery/door/poddoor/two_tile/secure
 	icon = 'icons/obj/structures/doors/1x2blast_hor.dmi'
 	openspeed = 17
-	unslashable = TRUE
 	unacidable = TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/vertical/secure
@@ -325,7 +320,6 @@
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, relativewall_neighbours)), 10)
 
 /obj/structure/machinery/door/poddoor/almayer/locked
-	unslashable = TRUE
 	unacidable = TRUE
 
 /obj/structure/machinery/door/poddoor/almayer/locked/attackby(obj/item/C as obj, mob/user as mob)

--- a/code/modules/mob/living/carbon/xenomorph/ai/movement/base_define.dm
+++ b/code/modules/mob/living/carbon/xenomorph/ai/movement/base_define.dm
@@ -45,7 +45,7 @@
 
 	if(idle_xeno.move_to_next_turf(home_turf, home_locate_range))
 		if(get_dist(home_turf, idle_xeno) <= 0)
-			idle_xeno.set_resting(TRUE, FALSE, TRUE)
+			idle_xeno.set_resting(TRUE, FALSE)
 	else
 		home_turf = null
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_ai_interaction.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_ai_interaction.dm
@@ -122,6 +122,7 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 
 	return
 
+
 /////////////////////////////
 //          MOBS           //
 /////////////////////////////
@@ -218,7 +219,7 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 	if(!.)
 		return
 
-	return VEHICLE_PENALTY
+	return SENTRY_PENALTY
 
 
 /////////////////////////////
@@ -228,13 +229,6 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 	if(X.claw_type == CLAW_TYPE_VERY_SHARP || (X.claw_type >= CLAW_TYPE_SHARP && !reinforced))
 		return ..()
 	return WINDOW_FRAME_PENALTY
-
-/obj/structure/barricade/handrail/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
-	. = ..()
-	if(!.)
-		return
-
-	return DOOR_PENALTY
 
 
 /////////////////////////////
@@ -247,6 +241,13 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 
 	return BARRICADE_PENALTY
 
+/obj/structure/barricade/handrail/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
+	. = ..()
+	if(!.)
+		return
+
+	return DOOR_PENALTY
+
 
 /////////////////////////////
 //          FIRE           //
@@ -256,6 +257,17 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 		return 0
 
 	return FIRE_PENALTY
+
+
+/////////////////////////////
+//          WALLS          //
+/////////////////////////////
+/turf/closed/wall/resin/xeno_ai_obstacle(mob/living/carbon/xenomorph/xeno, direction, turf/target)
+	. = ..()
+	if(!.)
+		return
+
+	return WALL_PENALTY
 
 
 /////////////////////////////
@@ -272,6 +284,11 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 
 	return OPEN_TURF_PENALTY
 
+/// For now there is no attack_alien() proc overrides on any child of /turf/open
+/// Also, we don't want xenos swiping all around - forbit the clicking!
+/turf/open/xeno_ai_act(mob/living/carbon/xenomorph/X)
+	return FALSE
+
 /// Space, do NOT path into space.
 /turf/open/space/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
 	. = ..()
@@ -279,3 +296,18 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 		return
 
 	return INFINITY
+
+
+/////////////////////////////
+//          RIVER          //
+/////////////////////////////
+/turf/open/gm/river/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
+	. = ..()
+	if(!. && !covered)
+		. *= base_river_slowdown
+
+/turf/open/gm/river/desert/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
+	if(toxic && !covered)
+		return FIRE_PENALTY
+
+	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_ai_interaction.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_ai_interaction.dm
@@ -303,8 +303,8 @@ At bare minimum, make sure the relevant checks from parent types gets copied in 
 /////////////////////////////
 /turf/open/gm/river/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
 	. = ..()
-	if(!. && !covered)
-		. *= base_river_slowdown
+	if(. && !covered)
+		. += base_river_slowdown
 
 /turf/open/gm/river/desert/xeno_ai_obstacle(mob/living/carbon/xenomorph/X, direction, turf/target)
 	if(toxic && !covered)


### PR DESCRIPTION
# About the pull request

A few more tweaks and fixes for AI interactions and loops

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: AI will try and avoid stepping in toxic water
code: Xeno resting now isn't instant in most cases
code: Sentry xeno_ai_obstacle() now returns SENTRY_PENALTY instead of VEHICLE_PENALTY
fix: check_special_blockers() now properly checks for types of types listed in XENO_AI_SPECIAL_BLOCKERS
fix: AI will now act less stupid when it comes to poddoors and shutters
fix: Xenos are no longer swipe on floor for no reason
refactor: Penalty defines now placed in increasing order
/:cl:
