### PR TITLE
Adds technician backpack and satchel

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -95,6 +95,7 @@
 
 		list("BACKPACK", -1, null, null, null),
 		list("Lightweight IMP Backpack", round(scale * 15), /obj/item/storage/backpack/marine, VENDOR_ITEM_REGULAR),
+		list("USCM Technician Backpack", round(scale * 15), /obj/item/storage/backpack/marine/tech, VENDOR_ITEM_REGULAR),
 		list("USCM Satchel", round(scale * 15), /obj/item/storage/backpack/marine/satchel, VENDOR_ITEM_REGULAR),
 		list("Technician Chestrig", round(scale * 15), /obj/item/storage/backpack/marine/satchel/tech, VENDOR_ITEM_REGULAR),
 		list("Shotgun Scabbard", round(scale * 5), /obj/item/storage/large_holster/m37, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -96,6 +96,7 @@
 		list("BACKPACK", -1, null, null, null),
 		list("Lightweight IMP Backpack", round(scale * 15), /obj/item/storage/backpack/marine, VENDOR_ITEM_REGULAR),
 		list("USCM Satchel", round(scale * 15), /obj/item/storage/backpack/marine/satchel, VENDOR_ITEM_REGULAR),
+		list("Technician Chestrig", round(scale * 15), /obj/item/storage/backpack/marine/satchel/tech, VENDOR_ITEM_REGULAR),
 		list("Shotgun Scabbard", round(scale * 5), /obj/item/storage/large_holster/m37, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED BACKPACKS", -1, null, null),


### PR DESCRIPTION
Adds the technician chestrig satchel to standard USCM vendors

It makes sense to have a purely visual alternative to the USCM satchel and backpack without having it be anything BUT visual like the welderpack or welder satchel would be, a few people have requested this in the past and I think it'd be a neat but minor addition to the available customization without being something major enough to make the marines stand out a whole lot from one another. If we want to go as far as using the movie as a reference, only Frost had the satchel to my knowledge and the rest of them had chest pouches and various other storage devices on them. If need be, I can see about changing the sprite to make it way less apparent. The backpack was included for consistency reasons, though I do think that the sprite looks better than the standard USCM backpack as well.

For me, the satchel doesn't exactly look attractive and takes up space on the back that I really like to leave open visually, although I'm sure other players might have their reasons for wanting this as well, though I can't speak for them.