### PR TITLE
Removes crafty pvts, redundant health hud.

### DIFF
--- a/code/datums/skills/uscm.dm
+++ b/code/datums/skills/uscm.dm
@@ -8,26 +8,12 @@ United States Colonial Marines
 	name = "Private"
 	//same as default
 
-/datum/skills/pfc/crafty
-	name = "Crafty Private"
-	skills = list(
-		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_TRAINED,
-		SKILL_ENGINEER = SKILL_ENGINEER_TRAINED,
-	)
-
 /datum/skills/combat_medic
 	name = "Combat Medic"
 	skills = list(
 		SKILL_MEDICAL = SKILL_MEDICAL_MEDIC,
 		SKILL_SURGERY = SKILL_SURGERY_NOVICE,
 		SKILL_JTAC = SKILL_JTAC_BEGINNER,
-	)
-
-/datum/skills/combat_medic/crafty
-	name = "Crafty Combat Medic"
-	skills = list(
-		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_TRAINED,
-		SKILL_ENGINEER = SKILL_ENGINEER_TRAINED,
 	)
 
 /datum/skills/combat_engineer

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -418,7 +418,7 @@
 	rank = JOB_SQUAD_MARINE
 	paygrade = "ME2"
 	role_comm_title = "A-RFN"
-	skills = /datum/skills/pfc/crafty
+	skills = /datum/skills/pfc
 	faction = FACTION_MARSHAL
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE)
 
@@ -590,10 +590,6 @@
 	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/hypospray/autoinjector/emergency, WEAR_IN_BELT)
 	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/hypospray/autoinjector/emergency, WEAR_IN_BELT)
 	new_human.equip_to_slot_or_del(new /obj/item/bodybag/cryobag, WEAR_IN_BELT)
-	if(new_human.disabilities & NEARSIGHTED)
-		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/prescription, WEAR_EYES)
-	else
-		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine, WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife, WEAR_FEET)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/box/MRE, WEAR_IN_BACK)

--- a/code/modules/gear_presets/dust_raider.dm
+++ b/code/modules/gear_presets/dust_raider.dm
@@ -26,7 +26,7 @@
 	rank = JOB_SQUAD_MARINE
 	paygrade = "ME2"
 	role_comm_title = "RFN"
-	skills = /datum/skills/pfc/crafty
+	skills = /datum/skills/pfc
 
 /datum/equipment_preset/dust_raider/private/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -14,7 +14,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	faction = FACTION_PIRATE
 
-	skills = /datum/skills/pfc/crafty
+	skills = /datum/skills/pfc
 
 /datum/equipment_preset/fun/pirate/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel(new_human), WEAR_BACK)
@@ -417,7 +417,7 @@
 
 	uses_special_name = TRUE
 
-	skills = /datum/skills/pfc/crafty // about equivalent to a marine
+	skills = /datum/skills/pfc // about equivalent to a marine
 
 	assignment = "Monkey"
 	rank = "Monkey"

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -593,7 +593,7 @@
 	rank = JOB_SQUAD_MARINE
 	paygrade = "ME2"
 	role_comm_title = "RFN"
-	skills = /datum/skills/pfc/crafty
+	skills = /datum/skills/pfc
 
 	minimap_icon = "private"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
crafty PVTs have a craft skill inferior to the default of PVTs, which is a bit strange, so I removed them.

also removed a redundant health hud on the anchorpoint medic, as helmet optics already exist.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
everyone should be able to cade
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: anchorpoint marines and dust raiders are now able to construct like other marines.
del: removed redundant health hud on anchorpoint corpsman
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
