### PR TITLE
Fixes SG ammo can and a storage exploit

### DIFF
--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -129,8 +129,8 @@
 	desc = "A small case containing the once-standard sidearm of the UPP, the Type 73, and two additional magazines. The contained sidearm is probably looted off a dead officer or from a captured stockpile, either way this thing is worth a pretty penny."
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "matebacase"
-	w_class = SIZE_MEDIUM
-	max_w_class = SIZE_MEDIUM
+	w_class = SIZE_LARGE
+	max_w_class = SIZE_LARGE
 	storage_slots = 3
 
 /obj/item/storage/box/upp/fill_preset_inventory()
@@ -143,8 +143,8 @@
 	desc = "A relatively large storage case containing the 1911 and additional magazines. Purchased by enlisted or aspiring PMCs looking to carry a timeless classic"
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "matebacase"
-	w_class = SIZE_MEDIUM
-	max_w_class = SIZE_MEDIUM
+	w_class = SIZE_LARGE
+	max_w_class = SIZE_LARGE
 	storage_slots = 3
 	
 /obj/item/storage/box/M1911_loadout/fill_preset_inventory()

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -130,7 +130,7 @@
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "matebacase"
 	w_class = SIZE_LARGE
-	max_w_class = SIZE_LARGE
+	max_w_class = SIZE_MEDIUM
 	storage_slots = 3
 
 /obj/item/storage/box/upp/fill_preset_inventory()
@@ -144,7 +144,7 @@
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "matebacase"
 	w_class = SIZE_LARGE
-	max_w_class = SIZE_LARGE
+	max_w_class = SIZE_MEDIUM
 	storage_slots = 3
 	
 /obj/item/storage/box/M1911_loadout/fill_preset_inventory()

--- a/code/modules/projectiles/ammo_boxes/round_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/round_boxes.dm
@@ -48,6 +48,7 @@
 	overlay_content = "_reg"
 	default_ammo = /datum/ammo/bullet/smartgun
 	caliber = "10x28mm"
+	bullet_amount = 1000
 	max_bullet_amount = 1000
 
 /obj/item/ammo_box/rounds/smartgun/empty


### PR DESCRIPTION
I previously added SG round boxes / ammo cans with the intention of holding 1000 rounds for 2 drums for GM-spawned resupply, but I messed up and they hold 600 rounds max. Fixed.

Fixes a storage exploit where people are taking loadout pistol boxes and filling them full of shit and putting them in their drop pouch by making the boxes too big to hold in a drop pouch. You could cram like 3 SG drums in one and other bigger items.