### PR TITLE
Modifies some cosmetic effects, removes a little weirdness.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -999,7 +999,7 @@
 		if(damage_result <= 10)
 			bullet_ping(P)
 			visible_message(SPAN_AVOIDHARM("[src]'s armor deflects [P]!"))
-			if(damage_result <= 1)
+			if(damage_result < 1)
                 damage_result = 0
 			if(P.ammo.sound_armor) playsound(src, P.ammo.sound_armor, 50, 1)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -994,12 +994,13 @@
 
 		damage_result = armor_damage_reduction(GLOB.marine_ranged, damage, armor, P.ammo.penetration)
 
-		if(damage_result <= 5)
+		if(damage_result <= 20)
 			to_chat(src,SPAN_XENONOTICE("Your armor absorbs the force of [P]!"))
-		if(damage_result <= 3)
-			damage_result = 0
+		if(damage_result <= 10)
 			bullet_ping(P)
 			visible_message(SPAN_AVOIDHARM("[src]'s armor deflects [P]!"))
+			if(damage_result <= 1)
+                damage_result = 0
 			if(P.ammo.sound_armor) playsound(src, P.ammo.sound_armor, 50, 1)
 
 	if(P.ammo.debilitate && stat != DEAD && ( damage || ( ammo_flags & AMMO_IGNORE_RESIST) ) )  //They can't be dead and damage must be inflicted (or it's a xeno toxin).

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -995,10 +995,11 @@
 		damage_result = armor_damage_reduction(GLOB.marine_ranged, damage, armor, P.ammo.penetration)
 
 		if(damage_result <= 20)
-			to_chat(src,SPAN_XENONOTICE("Your armor absorbs the force of [P]!"))
+			to_chat(src,SPAN_XENONOTICE("Your armor reduces the power of [P]!"))
+			bullet_ping(P)
 		if(damage_result <= 10)
 			bullet_ping(P)
-			visible_message(SPAN_AVOIDHARM("[src]'s armor deflects [P]!"))
+			visible_message(SPAN_AVOIDHARM("[src]'s armor defeats [P]!"))
 			if(damage_result < 1)
                 damage_result = 0
 			if(P.ammo.sound_armor) playsound(src, P.ammo.sound_armor, 50, 1)


### PR DESCRIPTION
# summary
- previously, if your damage after armor was <= 3 it would negate. this adds a little weirdness to some already slightly RNG affected damage. 
- now it only takes effect after being below 1, which might help with fractional damage weirdness.
- increases the thresholds at which armor sparks occur. it looks cool, but doesn't actually do anything. Immersion without having to modify all the armor values?