### PR TITLE
Slightly reduces crusher spawn sound falloff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -83,7 +83,7 @@
 	. = ..()
 	AddComponent(/datum/component/footstep, 2, 50, 15, 1, "metalbang")
 
-	playsound(src, 'sound/voice/alien_death_unused.ogg', 100, TRUE, 30)
+	playsound(src, 'sound/voice/alien_death_unused.ogg', 100, TRUE, 30, falloff = 5)
 	for(var/mob/current_mob as anything in get_mobs_in_z_level_range(get_turf(src), 30) - src)
 		var/relative_dir = get_dir(current_mob, src)
 		var/final_dir = dir2text(relative_dir)


### PR DESCRIPTION
# About the pull request

Makes it so crusher spawn sound can be heard farther (actual volume wasn't changed)

# Explain why it's good for the game

In a middle of the fight, crusher roar may go unnoticed (most of the times), and seeing some large ass scary message without a proper SFX to it is mehhh.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
qol: Crusher spawn sound can be heard farther
/:cl:
