### PR TITLE
Adds MOPP M2 for ROLEPLAY

### DIFF
--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -114,6 +114,12 @@
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
 	adopts_squad_color = FALSE
 
+/obj/item/clothing/gloves/marine/pve_mopp
+	name = "\improper M2 MOPP gloves"
+	desc = "M2 MOPP gloves to protect your insides from nerve gas and deadly chemicals. You'd probably feel safer if there was duct tape wrapped around these."
+	icon_state = "cbrn"
+	item_state = "cbrn"
+
 /obj/item/clothing/gloves/marine/veteran
 	name = "armored gloves"
 	desc = "Non-standard kevlon fiber gloves. They're insulated and heavily armored."

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -31,6 +31,17 @@
 	icon_state = "kutjevo_respirator"
 	item_state = "kutjevo_respirator"
 
+/obj/item/clothing/mask/gas/pve_mopp
+	name = "M2 MOPP mask"
+	desc = "The M2 MOPP mask includes a full covering cowl that securely attaches to the MOPP suit. It is capable of protecting of a variety of radiological and biological threats."
+	icon = 'icons/obj/items/clothing/cm_hats.dmi'
+	icon_state = "cbrn_hood"
+	item_state = "cbrn_hood"
+	flags_inv_hide = HIDEEARS|HIDEFACE|HIDEALLHAIR
+	item_icons = list(
+		WEAR_FACE = 'icons/mob/humans/onmob/head_1.dmi'
+	)
+
 /obj/item/clothing/mask/gas/pmc
 	name = "\improper M8 pattern armored balaclava"
 	desc = "An armored balaclava designed to conceal both the identity of the operator and act as an air-filter."
@@ -69,6 +80,11 @@
 	desc = "A superior balaclava worn by the Iron Bears."
 	icon_state = "bear_mask"
 	anti_hug = 2
+
+/obj/item/clothing/mask/gas/pmc/marsoc
+	name = "\improper SOF armored balaclava"
+	desc = "Designed for maximum protection -- and badassery. Provides protection against facial attacks, filters toxins, and conceals the wearer's identity."
+	icon_state = "balaclava"
 
 
 

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -81,6 +81,14 @@
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMLOW
 	knife_type = /obj/item/attachable/bayonet
 
+/obj/item/clothing/shoes/marine/pve_mopp
+	name = "\improper M2 MOPP boots"
+	desc = "M2 MOPP boots excel at keeping viscera or other biological contaminants away from your feet."
+	icon_state = "cbrn"
+	item_state = "cbrn"
+	armor_rad = CLOTHING_ARMOR_GIGAHIGHPLUS
+	armor_bio = CLOTHING_ARMOR_GIGAHIGHPLUS
+
 /obj/item/clothing/shoes/dress
 	name = "dress shoes"
 	desc = "Pre-polished fancy dress shoes. You can see your reflection in them."

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -1042,6 +1042,20 @@
 	icon_state = "rmc_uniform_lt"
 	worn_state = "rmc_uniform_lt"
 
+/obj/item/clothing/under/marine/pve_mopp
+	name = "\improper M2 MOPP suit"
+	desc = "M2 MOPP suits are purpose built to defend the wearer against biological and radioactive contaminants, from nerve gas to nuclear fallout."
+	desc_lore = "The several-paragraph long expository pamphlet that usually comes with these is missing."
+	flags_atom = NO_NAME_OVERRIDE|NO_SNOW_TYPE
+	flags_jumpsuit = NO_FLAGS
+	icon_state = "cbrn"
+	worn_state = "cbrn"
+
+	item_icons = list(
+		WEAR_BODY = 'icons/mob/humans/onmob/uniform_1.dmi',
+	)
+
+
 /obj/item/clothing/under/marine/cbrn //CBRN MOPP suit
 	name = "\improper M3 MOPP suit"
 	desc = "M3 MOPP suits are specially designed and engineered to protect the wearer from unshielded exposure to any Chemical, Biological, Radiological, or Nuclear (CBRN) threats in the field. Despite somewhat resembling commonplace synthetic rubber HAZMAT suits, the Venlar composition provides a significantly more dense and durable baseline material, allowing for modifications without the loss of its air-tight nature. The wearer’s comfort has been significantly taken into consideration, with the suit providing sufficient freedom of movement for even delicate maneuvers and movements once it is donned. As the sealed environment retains many issues from the past, measures have been taken to significantly reduce the suit's passive heat absorption and increase internal absorbance through linings, as well as the capability to fully integrate with external cooling, air cycling, and other life support systems. Strips of M11 detector paper are included with each suit, designed to be slotted into the dominant arm of the wearer’s protective suit, the non-dominant wrist, and then back to the knee, providing at-a-glance warning signs across alternating sides of the body while working. The arm and knee markers are intended to be on the user's dominant The papers change color upon contact with harmful chemical agents, displaying a clear white initially and turning red when activated. The suit has a recommended lifespan of twenty-four hours once contact with a toxic environment is made, but depending on the severity this can be shortened to eight hours or less. Beyond that point, the accuracy of the detector papers deteriorates significantly, as does the protection of the suit itself."


### PR DESCRIPTION
MOPP M2. Visually it is the same as MOPP M3 but it's able to be worn by marines under their armor and with a helmet. Has no mechanical differences from standard marine uniforms. Instead of being a hat the M2 mask goes in the mask slot.

mopprine attached

![mopprine](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/25943228/4335da27-43d4-404d-8f11-7095f91712d9)
