### PR TITLE
M5 Gasmask now functions

### DIFF
--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -496,6 +496,30 @@
 	desc = "The USCM had its funding pulled for these when it became apparent that not every deployed enlisted was wearing a helmet 24/7; much to the bafflement of UA High Command."
 	icon_state = "helmet_gasmask"
 
+/obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/helmet_internal_inventory)
+	..()
+	if(!istype(helmet_internal_inventory))
+		return
+	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
+
+	if(!istype(helmet_item))
+		return
+
+	helmet_item.flags_inventory |= BLOCKGASEFFECT
+	helmet_item.flags_inv_hide |= HIDEFACE
+
+/obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/helmet_internal_inventory)
+	..()
+	if(!istype(helmet_internal_inventory))
+		return
+	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
+
+	if(!istype(helmet_item))
+		return
+
+	helmet_item.flags_inventory &= ~(BLOCKGASEFFECT)
+	helmet_item.flags_inv_hide &= ~(HIDEFACE)
+
 /obj/item/prop/helmetgarb/trimmed_wire
 	name = "trimmed barbed wire"
 	desc = "It is a length of barbed wire that's had most of the sharp points filed down so that it is safe to handle."


### PR DESCRIPTION
# About the pull request

Makes the M5 Helmet Gasmask actually function as a gasmask, no matter how minimal that function is.

# Explain why it's good for the game

Consistency, players wearing helmet gasmasks will also be immune to any gasses that are supposed to be blocked by one (and getting gassed is a whole lot more likely here than PvP)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/PvE-CMSS13/PvE-CMSS13/assets/95509996/71c25d0a-db36-4575-b243-0069924453c5

(PvP clip)

</details>

# Changelog

:cl: Ediblebomb
add: M5 Helmet Gasmask now functions as a gasmask when in a marine helmet (and yes, gasmasks do still have some functionality)
/:cl: