### PR TITLE
Colored Campfire Light 

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -658,6 +658,7 @@
 	health = 150
 	light_range = 6
 	light_on = TRUE
+	light_color = LIGHT_COLOUR_FIRE
 	unslashable = TRUE
 	/// What obj this becomes when it gets to its next stage of construction / ignition
 	var/frame_type


### PR DESCRIPTION
# About the pull request

Makes campfire light use the light "colour" for fire.

# Explain why it's good for the game

Vibes and immersion, a campfire glowing pure white doesn't make a lotta sense.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/95509996/10c2db7f-f8bd-4996-855e-d0fb8d1055c7)

</details>

# Changelog
:cl: Ediblebomb
add: Campfire light is now appropriately colored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
