### PR TITLE
glasses slot doesn't suck anymore

### DIFF
--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -139,14 +139,14 @@
 #define SUIT_LAYER 30
 #define SUIT_GARB_LAYER 29
 #define SUIT_SQUAD_LAYER 28
-#define GLASSES_LAYER 27
-#define BELT_LAYER 26
-#define SUIT_STORE_LAYER 25
-#define BACK_LAYER 24
-#define HAIR_LAYER 23
-#define HAIR_GRADIENT_LAYER 22
-#define FACIAL_LAYER 21
-#define EARS_LAYER 20
+#define BELT_LAYER 27
+#define SUIT_STORE_LAYER 26
+#define BACK_LAYER 25
+#define HAIR_LAYER 24
+#define HAIR_GRADIENT_LAYER 23
+#define FACIAL_LAYER 22
+#define EARS_LAYER 21
+#define GLASSES_LAYER 20
 #define FACEMASK_LAYER 19
 
 /// Unrevivable headshot overlays, suicide/execution.


### PR DESCRIPTION
# About the pull request
Moves layers around to make glasses actually look good in their dedicated slot.
# Explain why it's good for the game
Glasses won't look like ass in their own slot anymore.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/95509996/e6bb1664-6387-45d3-9300-e29fd2ff2a30)
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/95509996/b34d4403-1ba0-4f68-9513-a78e009c06f1)

</details>

# Changelog
:cl:
fix: Makes glasses not look like shit in the glasses slot. Is this a fix? I dunno but it's not like these show up in game anyway.
/:cl:
