### PR TITLE
Vehicle crashing tweaks

### DIFF
--- a/code/modules/vehicles/multitile/multitile_movement.dm
+++ b/code/modules/vehicles/multitile/multitile_movement.dm
@@ -159,7 +159,7 @@
 
 	// Crashed with something that stopped us
 	if(!can_move)
-		move_momentum = Floor(move_momentum/2)
+		move_momentum = trunc(move_momentum/2)
 		update_next_move()
 		interior_crash_effect()
 
@@ -251,10 +251,10 @@
 		return
 
 	// Not enough momentum for anything serious
-	if(abs(move_momentum) <= 1)
+	if(abs(move_momentum) < 1)
 		return
 
-	var/fling_distance = Ceiling(move_momentum/move_max_momentum) * 2
+	var/fling_distance = Ceiling(abs(move_momentum)/move_max_momentum) * 2
 	var/turf/target = interior.get_middle_turf()
 
 	for (var/x in 0 to fling_distance-1)
@@ -272,7 +272,7 @@
 			if(isliving(A))
 				var/mob/living/M = A
 
-				shake_camera(M, 2, Ceiling(move_momentum/move_max_momentum) * 1)
+				shake_camera(M, 2, Ceiling(abs(move_momentum)/move_max_momentum) * 1)
 				if(!M.buckled)
 					M.apply_effect(1, STUN)
 					M.apply_effect(2, WEAKEN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Corrects a few math issues and loosens tolerances so vehicle-crash-interior-flinging can actually happen now.

`move_momentum` can be positive for forward or negative for backward, so `Floor(move_momentum/2)` made forward crashes less intense and backward crashes more intense. Corrected to `trunc(move_momentum/2)`, which rounds towards zero consistently.

The maximum value for `move_momentum`, fittingly named `move_max_momentum`, is 2 for the APC and 3 for the tank. Because its divided by 2 and then floored, the max momentum actually fed to the `interior_crash_effect()` proc was 1* (3/2 = 1.5, floor(1.5) = 1). `interior_crash_effect()` has an early return for `if(abs(move_momentum) <= 1)`. Corrected to `if(abs(move_momentum) < 1)` so values of 1 still trigger the crash.

*except the tank moving backwards, (-3/2 = -1.5, floor(-1.5) = -2)

Correctly uses the magnitude of `move_momentum` in places where a negative number would cause inconsistent results, like `fling_distance` and camera shake strength.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

The code was there, implemented, called, but never actually fulfilled its own conditions -- except for the tank driving backwards at full speed, which can't be the only intended use.

If crashing wasn't desired, it would be better to remove it completely rather than leaving it in its bugged state.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Boots without issue. Crashing visual and fling effects now work for both forward and backward collisions.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: vehicle crashes more consistently fling loose contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
