### PR TITLE
Buffs platoon name size to 16

### DIFF
--- a/code/modules/admin/game_master/extra_buttons/rename_platoon.dm
+++ b/code/modules/admin/game_master/extra_buttons/rename_platoon.dm
@@ -28,8 +28,8 @@ GLOBAL_VAR_INIT(main_platoon_initial_name, GLOB.main_platoon_name)
 	if(!new_name || !istext(new_name))
 		return
 
-	if(length(new_name) > 10)
-		to_chat(src, SPAN_NOTICE("The platoon name should be 10 characters or less."))
+	if(length(new_name) > 16)
+		to_chat(src, SPAN_NOTICE("The platoon name should be 16 characters or less."))
 		return
 
 	var/old_name = GLOB.main_platoon_name


### PR DESCRIPTION
I was suggested to change the platoon name size to 16 to allow for greater variation in platoon names. When playing platco I felt like there were way too few options to change my name to given the very small character limit of 10. Upping it to 16 gives some room for more options without outright doubling it.