### PR TITLE
Vulture Touchups & Fixes

### DIFF
--- a/code/game/objects/items/pamphlets.dm
+++ b/code/game/objects/items/pamphlets.dm
@@ -200,7 +200,7 @@
 		to_chat(user, SPAN_WARNING("You know this already!"))
 		return FALSE
 
-	if(user.job != JOB_SQUAD_MARINE)
+	if(!(user.job in JOB_SQUAD_ROLES_LIST))
 		to_chat(user, SPAN_WARNING("Only squad riflemen can use this."))
 		return FALSE
 

--- a/code/game/objects/structures/vulture_spotter.dm
+++ b/code/game/objects/structures/vulture_spotter.dm
@@ -183,7 +183,10 @@
 	unscope()
 	scope_attached = FALSE
 	desc = initial(desc) + " Though, it doesn't seem to have one attached yet."
-	new /obj/item/device/vulture_spotter_scope(get_turf(src), bound_rifle)
+	if(skillless)
+		new /obj/item/device/vulture_spotter_scope/skillless(get_turf(src), bound_rifle)
+	else
+		new /obj/item/device/vulture_spotter_scope(get_turf(src), bound_rifle)
 
 /// Handler for user folding up the tripod, picking it up
 /obj/structure/vulture_spotter_tripod/proc/fold_up(mob/user)

--- a/code/modules/projectiles/guns/boltaction.dm
+++ b/code/modules/projectiles/guns/boltaction.dm
@@ -171,11 +171,17 @@
 
 /obj/item/weapon/gun/boltaction/vulture/update_icon()
 	..()
+	var/new_icon_state = src::icon_state
+	if(!current_mag)
+		new_icon_state += "_e"
+
+	icon_state = new_icon_state
+
 	if(!bolted)
 		overlays += "vulture_bolt_open"
 
 
-/obj/item/weapon/gun/boltaction/vulture/set_gun_config_values() //check that these work
+/obj/item/weapon/gun/boltaction/vulture/set_gun_config_values()
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_VULTURE)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_7
@@ -192,13 +198,11 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19, "rail_x" = 11, "rail_y" = 24, "under_x" = 25, "under_y" = 14, "stock_x" = 11, "stock_y" = 15)
 
 /obj/item/weapon/gun/boltaction/vulture/able_to_fire(mob/user)
-	. = ..()
-	if(!.)
-		return
-
 	if(!bypass_trait && !HAS_TRAIT(user, TRAIT_VULTURE_USER))
 		to_chat(user, SPAN_WARNING("You don't know how to use this!"))
-		return
+		return FALSE
+
+	return ..()
 
 /obj/item/weapon/gun/boltaction/vulture/Fire(atom/target, mob/living/user, params, reflex, dual_wield)
 	var/obj/item/attachable/vulture_scope/scope = attachments["rail"]


### PR DESCRIPTION
# About the pull request

Mirrors https://github.com/cmss13-devs/cmss13/pull/6379

- Removes RFN requirement for pamphlet, now all squad roles can do it.
- Fixes the skillless spotting scope breaking on the 2nd redeployment
- Fixes the gun's magazine overlay disappearing when the gun ran out of
ammo
- Fixes the gun being usable without pamphlet

# Explain why it's good for the game

- The pamphlet change is happening because this gun is inherently an
event one. As such, I don't think it needs to be locked to _only_
riflemen.
- Fixes are good

# Changelog
:cl:
balance: All squad roles can now use M707 pamphlets
fix: Skillless M707 spotting scopes now consistently work.
fix: M707 magazine overlay no longer disappears when the gun is empty
with an inserted magazine
fix: Fixed M707 being usable without the correct trait
/:cl: