### PR TITLE
Lets marines bring cassette tapes from home.

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -573,9 +573,66 @@ var/global/list/gear_datums_by_name = list()
 	display_name = "Die, 20 sides"
 	path = /obj/item/toy/dice/d20
 
-/datum/gear/toy/walkman
+/datum/gear/cassettes
+	category = "Cassettes"
+
+/datum/gear/cassettes/walkman
 	display_name = "Walkman"
 	path = /obj/item/device/walkman
+
+/datum/gear/cassettes/pop1
+	display_name = "Blue Cassette"
+	path = /obj/item/device/cassette_tape/pop1
+	cost = 1
+
+/datum/gear/cassettes/pop2
+	display_name = "Rainbow Cassette"
+	path = /obj/item/device/cassette_tape/pop2
+	cost = 1
+
+/datum/gear/cassettes/pop3
+	display_name = "Orange Cassette"
+	path = /obj/item/device/cassette_tape/pop3
+	cost = 1
+
+/datum/gear/cassettes/pop4
+	display_name = "Blue Cassette"
+	path = /obj/item/device/cassette_tape/pop4
+	cost = 1
+
+/datum/gear/cassettes/heavymetal
+	display_name = "Red-Black Cassette"
+	path = /obj/item/device/cassette_tape/heavymetal
+	cost = 1
+
+/datum/gear/cassettes/hairmetal
+	display_name = "Red Striped Cassette"
+	path = /obj/item/device/cassette_tape/hairmetal
+	cost = 1
+
+/datum/gear/cassettes/indie
+	display_name = "Rising Sun Cassette"
+	path = /obj/item/device/cassette_tape/indie
+	cost = 1
+
+/datum/gear/cassettes/hiphop
+	display_name = "Blue Stripe Cassette"
+	path = /obj/item/device/cassette_tape/hiphop
+	cost = 1
+
+/datum/gear/cassettes/nam
+	display_name = "Green Cassette"
+	path = /obj/item/device/cassette_tape/nam
+	cost = 1
+
+/datum/gear/cassettes/ocean
+	display_name = "Ocean Cassette"
+	path = /obj/item/device/cassette_tape/ocean
+	cost = 1
+
+/datum/gear/cassettes/pouch
+	display_name = "Cassette Pouch"
+	path = 	/obj/item/storage/pouch/cassette
 
 /datum/gear/toy/crayon
 	display_name = "Crayon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Adds cassettes to the loadout menu, and moves the walkman to it's own category.
Seems weird that marines can bring a walkman, but no tapes for it.

PR is tested and everything. It SHOULD work. (maybe)

# Explain why it's good for the game
Not all maps have recreational vendors, and why have walkmans in the loadout if you cant get tapes for it?


# Testing Photographs and Procedure
I added it to my loadout and spawned in. It worked.

<summary>Screenshots & Videos</summary>

![billede](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/38206283/cf80280d-5a5d-424f-a52a-d2af7e34cb65)

![billede](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/38206283/5befe593-c8d3-4ac3-9381-84dd4bf232ea)

</details>




# Changelog

:cl:
add: Marines are now allowed to bring cassette tapes for their walkman.
/:cl: