### PR TITLE
Buffs CN20 Nerve Gas, adds ALD-91 LSD Gas

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -44,3 +44,4 @@ var/MAX_EXPLOSION_RANGE = 14
 #define VENT_GAS_SMOKE "Smoke"
 #define VENT_GAS_CN20 "CN20 Nerve Gas"
 #define VENT_GAS_CN20_XENO "CN20-X Nerve Gas"
+#define VENT_GAS_LSD "ALD-91 LSD Gas"

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -258,6 +258,7 @@
 	var/xeno_affecting = FALSE
 	opacity = FALSE
 	alpha = 75
+	time_to_live = 20
 
 /obj/effect/particle_effect/smoke/cn20/xeno
 	name = "CN20-X nerve gas"
@@ -300,7 +301,8 @@
 		xeno_creature.interference = 10
 		xeno_creature.blinded = TRUE
 	else
-		creature.apply_damage(12, OXY)
+		creature.apply_damage(12, TOX)
+		creature.apply_damage(2, BRAIN)
 	creature.SetEarDeafness(max(creature.ear_deaf, round(effect_amt*1.5))) //Paralysis of hearing system, aka deafness
 	if(!xeno_creature && !creature.eye_blind) //Eye exposure damage
 		to_chat(creature, SPAN_DANGER("Your eyes sting. You can't see!"))

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -358,7 +358,7 @@
 	for(var/mob/living/carbon/human/human in get_turf(src))
 		affect(human)
 
-/obj/effect/particle_effect/smoke/LSD/affect(mob/living/carbon/creature)
+/obj/effect/particle_effect/smoke/LSD/affect(mob/living/carbon/human/creature)
 	if(!istype(creature) || issynth(creature) || creature.stat == DEAD || isyautja(creature))
 		return FALSE
 

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -339,6 +339,33 @@
 		human_creature.recalculate_move_delay = TRUE
 	return TRUE
 
+/////////////////////////////////////////////
+// ALD-91 LSD Gas
+/////////////////////////////////////////////
+
+/obj/effect/particle_effect/smoke/LSD
+	name = "ALD-91 LSD Gas"
+	smokeranking = SMOKE_RANK_HIGH
+	color = "#80c7e4"
+	var/xeno_affecting = FALSE
+	opacity = FALSE
+	alpha = 75
+	time_to_live = 20
+	var/stun_chance = 60
+
+/obj/effect/particle_effect/smoke/LSD/Move()
+	. = ..()
+	for(var/mob/living/carbon/human/human in get_turf(src))
+		affect(human)
+
+/obj/effect/particle_effect/smoke/LSD/affect(mob/living/carbon/creature)
+	creature.hallucination += 15
+	creature.druggy += 1
+
+	if(prob(stun_chance))
+		creature.apply_effect(1, WEAKEN)
+
+
 //////////////////////////////////////
 // FLASHBANG SMOKE
 ////////////////////////////////////
@@ -641,6 +668,9 @@
 
 /datum/effect_system/smoke_spread/cn20/xeno
 	smoke_type = /obj/effect/particle_effect/smoke/cn20/xeno
+
+/datum/effect_system/smoke_spread/LSD
+	smoke_type = /obj/effect/particle_effect/smoke/LSD
 
 // XENO SMOKES
 

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -346,7 +346,7 @@
 /obj/effect/particle_effect/smoke/LSD
 	name = "ALD-91 LSD Gas"
 	smokeranking = SMOKE_RANK_HIGH
-	color = "#80c7e4"
+	color = "#6e006e"
 	var/xeno_affecting = FALSE
 	opacity = FALSE
 	alpha = 75
@@ -359,6 +359,14 @@
 		affect(human)
 
 /obj/effect/particle_effect/smoke/LSD/affect(mob/living/carbon/creature)
+if(!istype(creature) || issynth(creature) || creature.stat == DEAD || isyautja(creature))
+		return FALSE
+
+	if(creature.wear_mask && (creature.wear_mask.flags_inventory & BLOCKGASEFFECT))
+		return FALSE
+	if(human_creature && (human_creature.head && (human_creature.head.flags_inventory & BLOCKGASEFFECT)))
+		return FALSE
+
 	creature.hallucination += 15
 	creature.druggy += 1
 

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -277,10 +277,14 @@
 /obj/effect/particle_effect/smoke/cn20/affect(mob/living/carbon/creature)
 	var/mob/living/carbon/xenomorph/xeno_creature
 	var/mob/living/carbon/human/human_creature
+	var/datum/internal_organ/lungs/lungs
+	var/datum/internal_organ/eyes/eyes
 	if(isxeno(creature))
 		xeno_creature = creature
 	else if(ishuman(creature))
 		human_creature = creature
+		lungs = human_creature.internal_organs_by_name["lungs"]
+		eyes = human_creature.internal_organs_by_name["eyes"]
 	if(!istype(creature) || issynth(creature) || creature.stat == DEAD)
 		return FALSE
 	if(!xeno_affecting && xeno_creature)
@@ -298,15 +302,18 @@
 	if(xeno_creature)
 		if(xeno_creature.interference < 4)
 			to_chat(xeno_creature, SPAN_XENOHIGHDANGER("Your awareness dims to a small area!"))
+		creature.apply_damage(20, BRUTE)
 		xeno_creature.interference = 10
 		xeno_creature.blinded = TRUE
 	else
 		creature.apply_damage(12, TOX)
 		creature.apply_damage(2, BRAIN)
+		lungs.take_damage(2)
 	creature.SetEarDeafness(max(creature.ear_deaf, round(effect_amt*1.5))) //Paralysis of hearing system, aka deafness
-	if(!xeno_creature && !creature.eye_blind) //Eye exposure damage
+	if(!xeno_creature) //Eye exposure damage
 		to_chat(creature, SPAN_DANGER("Your eyes sting. You can't see!"))
 		creature.SetEyeBlind(round(effect_amt/3))
+		eyes.take_damage(2)
 	if(!xeno_creature && creature.coughedtime != 1 && !creature.stat) //Coughing/gasping
 		creature.coughedtime = 1
 		if(prob(50))

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -364,7 +364,7 @@
 
 	if(creature.wear_mask && (creature.wear_mask.flags_inventory & BLOCKGASEFFECT))
 		return FALSE
-	if(human_creature && (human_creature.head && (human_creature.head.flags_inventory & BLOCKGASEFFECT)))
+	if(creature.head.flags_inventory & BLOCKGASEFFECT)
 		return FALSE
 
 	creature.hallucination += 15

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -359,7 +359,7 @@
 		affect(human)
 
 /obj/effect/particle_effect/smoke/LSD/affect(mob/living/carbon/creature)
-if(!istype(creature) || issynth(creature) || creature.stat == DEAD || isyautja(creature))
+	if(!istype(creature) || issynth(creature) || creature.stat == DEAD || isyautja(creature))
 		return FALSE
 
 	if(creature.wear_mask && (creature.wear_mask.flags_inventory & BLOCKGASEFFECT))

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -347,7 +347,6 @@
 	name = "ALD-91 LSD Gas"
 	smokeranking = SMOKE_RANK_HIGH
 	color = "#6e006e"
-	var/xeno_affecting = FALSE
 	opacity = FALSE
 	alpha = 75
 	time_to_live = 20

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -484,7 +484,7 @@
 	/// The typepath of the nerve gas
 	var/nerve_gas_type = /datum/effect_system/smoke_spread/cn20
 	/// The radius the gas will reach
-	var/nerve_gas_radius = 2
+	var/nerve_gas_radius = 4
 
 /obj/item/explosive/grenade/nerve_gas/Initialize(mapload, ...)
 	. = ..()
@@ -504,6 +504,38 @@
 /obj/item/explosive/grenade/nerve_gas/xeno
 	name = "\improper CN20-X canister grenade"
 	nerve_gas_type = /datum/effect_system/smoke_spread/cn20/xeno
+
+/*
+//================================================
+			LSD Gas Grenades
+//================================================
+*/
+/obj/item/explosive/grenade/LSD
+	name = "\improper ALD-91 canister grenade"
+	desc = "A canister grenade of nonlethal LSD gas. It is set to detonate in 4 seconds."
+	icon_state = "flashbang2"//temp icon
+	det_time = 40
+	item_state = "grenade_phos_clf"//temp icon
+	underslug_launchable = FALSE
+	harmful = TRUE
+	antigrief_protection = FALSE
+	var/datum/effect_system/smoke_spread/LSD/LSD_gas
+	var/LSD_gas_radius = 4
+
+/obj/item/explosive/grenade/LSD/Initialize()
+	. = ..() //if it ain't broke don't fix it
+	LSD_gas = new /datum/effect_system/smoke_spread/LSD
+	LSD_gas.attach(src)
+
+/obj/item/explosive/grenade/LSD/Destroy()
+	QDEL_NULL(LSD_gas)
+	return ..()
+
+/obj/item/explosive/grenade/LSD/prime()
+	playsound(src.loc, 'sound/effects/smoke.ogg', 25, 1, 4)
+	LSD_gas.set_up(LSD_gas_radius, 0, get_turf(src), null, 6)
+	LSD_gas.start()
+	qdel(src)
 
 /*
 //================================================

--- a/code/game/objects/structures/pipes/vents/vents.dm
+++ b/code/game/objects/structures/pipes/vents/vents.dm
@@ -139,7 +139,7 @@
 		if(welded)
 			to_chat(usr, SPAN_WARNING("You cannot release gas from a welded vent."))
 			return FALSE
-		var/list/options = list(VENT_GAS_SMOKE, VENT_GAS_CN20, VENT_GAS_CN20_XENO)
+		var/list/options = list(VENT_GAS_SMOKE, VENT_GAS_CN20, VENT_GAS_CN20_XENO, VENT_GAS_LSD)
 		var/gas_choice = tgui_input_list(user, "What gas do you wish to use?", "Gas Choice", options, 20 SECONDS)
 		if(!gas_choice)
 			return FALSE
@@ -166,6 +166,8 @@
 			spreader = new /datum/effect_system/smoke_spread/cn20
 		if(VENT_GAS_CN20_XENO)
 			spreader = new /datum/effect_system/smoke_spread/cn20/xeno
+		if(VENT_GAS_LSD)
+			spreader = new /datum/effect_system/smoke_spread/LSD
 	if(!spreader)
 		return FALSE
 	gas_holder = spreader


### PR DESCRIPTION
### Buff CN20 so it actually kills people
- 12 oxy/second->12 tox/second
- 2 radius->4 radius
- 8 seconds->20 seconds
- +2 eyes, lungs, and brain damage/second
- +20 damage/second against xenos (CN20X)
### Make nonlethal gas because you might need it I guess
+ALD-91 (it's LSD gas but it stuns you because the hallucination system SUCKS)
- 4 radius
- porple (#6e006e)
- lasts 20 seconds
- adds 15 to the hallucination counter/second
- adds 1 to the "druggy" (it's the funny rainbow lights) counter/second
- 60% stun chance/second
- can be deployed from vents like CN20