### PR TITLE
Bumps Python version because it refuses to work

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -18,4 +18,4 @@ export NODE_VERSION_PRECISE=14.16.1
 export SPACEMAN_DMM_VERSION=suite-1.8
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.7.9
+export PYTHON_VERSION=3.9.0


### PR DESCRIPTION
# About the pull request

Mirror of https://github.com/cmss13-devs/cmss13/pull/6654

Python some reason refuses to run scripts using 3.7 now. This bumps it to version TG uses when they first introduced maplint.

**Of note it may be necessary for contributors to run either bootstrap\python.bat or tools\hooks\install.bat to have their tools working again.**

# Explain why it's good for the game

Fixes 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/25e45723-9183-452b-9c78-63f9bf35a45f)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Hooks install: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/5a770e0c-7383-4dc5-b97e-cd5f3ea92d83)

</details>


# Changelog

No player facing changes.
