### PR TITLE
Removes base area lighting from the dropships.

### DIFF
--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -121,6 +121,7 @@
 	soundscape_interval = 30
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/midway/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))
@@ -147,6 +148,7 @@
 	soundscape_interval = 30
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/cyclone/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))
@@ -161,6 +163,7 @@
 	soundscape_interval = 30
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/tornado/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))
@@ -174,6 +177,7 @@
 	soundscape_interval = 30
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/typhoon/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))
@@ -187,6 +191,7 @@
 	soundscape_interval = 30
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/tripoli/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))

--- a/maps/shuttles/dropship_cyclone.dmm
+++ b/maps/shuttles/dropship_cyclone.dmm
@@ -598,11 +598,8 @@
 	pixel_y = 8
 	},
 /obj/structure/machinery/light/small{
-	light_color = "#C02526";
-	color = "#C02526";
 	dir = 4;
-	pixel_y = 15;
-	breakable = 0
+	pixel_y = 15
 	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/shuttle/cyclone)

--- a/maps/shuttles/dropship_midway.dmm
+++ b/maps/shuttles/dropship_midway.dmm
@@ -19,11 +19,8 @@
 	phone_id = "Midway"
 	},
 /obj/structure/machinery/light/small{
-	light_color = "#C02526";
-	color = "#C02526";
 	dir = 4;
-	pixel_y = 15;
-	breakable = 0
+	pixel_y = 15
 	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/shuttle/midway)

--- a/maps/shuttles/dropship_tornado.dmm
+++ b/maps/shuttles/dropship_tornado.dmm
@@ -233,11 +233,8 @@
 	pixel_y = 8
 	},
 /obj/structure/machinery/light/small{
-	light_color = "#C02526";
-	color = "#C02526";
 	dir = 4;
-	pixel_y = 15;
-	breakable = 0
+	pixel_y = 15
 	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/shuttle/tornado)

--- a/maps/shuttles/dropship_tripoli.dmm
+++ b/maps/shuttles/dropship_tripoli.dmm
@@ -506,11 +506,8 @@
 	pixel_x = 6
 	},
 /obj/structure/machinery/light/small{
-	light_color = "#C02526";
-	color = "#C02526";
 	dir = 4;
-	pixel_y = 15;
-	breakable = 0
+	pixel_y = 15
 	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/shuttle/tripoli)

--- a/maps/shuttles/dropship_typhoon.dmm
+++ b/maps/shuttles/dropship_typhoon.dmm
@@ -151,11 +151,8 @@
 	pixel_x = 6
 	},
 /obj/structure/machinery/light/small{
-	light_color = "#C02526";
-	color = "#C02526";
 	dir = 4;
-	pixel_y = 15;
-	breakable = 0
+	pixel_y = 15
 	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/shuttle/tornado)


### PR DESCRIPTION
# About the pull request
Base area lighting in a dropship with a closed roof and _lights on the map_ doesn't really have a reason to exist, this also adds a light to the cockpit so it's not pitch black in there.
# Explain why it's good for the game
Base area lighting can look pretty silly (see below image), and the dropships already have lights mapped.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
![image](https://github.com/user-attachments/assets/8c511c35-e86a-4cf7-900d-ad1d982898f5)
![image](https://github.com/user-attachments/assets/ed5b2334-bab1-449e-8238-f15cead54cc0)
</details>

# Changelog
:cl: Ediblebomb
maptweak: Dropships no longer have base area lighting.
/:cl: