### PR TITLE
Vehicle Nuke death fix port

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -420,6 +420,17 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 				continue
 			alive_mobs |= current_mob
 
+	for(var/datum/interior/interior in SSinterior.interiors)
+		if(!interior.exterior || interior.exterior.z != z)
+			continue
+
+		for(var/mob/living/passenger in interior.get_passengers())
+			if(!(passenger in (alive_mobs + dead_mobs)))
+				if(passenger.stat != DEAD)
+					passenger.death(create_cause_data("nuclear explosion"))
+				for(var/obj/item/alien_embryo/embryo in passenger)
+					qdel(embryo)
+
 	for(var/mob/current_mob in alive_mobs)
 		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
 			continue


### PR DESCRIPTION
# About the pull request
Ports over the fix that allows for the death of anyone in a vehicle in the same Z-level of a nuke
Thank you to TheGamerdk for the code: [https://github.com/cmss13-devs/cmss13/pull/8412]

# Explain why it's good for the game
You aren't surviving the nuke in an Abrams dummy.
You can still hop in a fridge and survive one, I did not know this.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: fixes surviving in a nuke on the same Z-level by hopping in a vehicle
/:cl:
