### PR TITLE
Improves candle use time

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -28,13 +28,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "candle1"
 	w_class = SIZE_TINY
 
-	var/wax = 800
+	var/wax = 3000
 
 /obj/item/tool/candle/update_icon()
 	var/i
-	if(wax>150)
+	if(wax>1500)
 		i = 1
-	else if(wax>80)
+	else if(wax>250)
 		i = 2
 	else i = 3
 	icon_state = "candle[i][heat_source ? "_lit" : ""]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Increases the amount of wax that is available for candles, allows for considerably longer use times.

# Explain why it's good for the game
Useful for sometimes long periods of darkness in colony settings, most candles barely lasted 10 minutes.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: candles last longer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
