### PR TITLE
tweaked point values for rec/misc gear in preferences

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -726,7 +726,7 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 /datum/gear/toy/film
 	display_name = "Camera film"
 	path = /obj/item/device/camera_film
-	cost = 1
+	cost = 0
 
 /datum/gear/toy/card
 	cost = 1
@@ -770,14 +770,17 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 
 /datum/gear/toy/d6
 	display_name = "Die, 6 sides"
+	cost = 1
 	path = /obj/item/toy/dice
 
 /datum/gear/toy/d20
 	display_name = "Die, 20 sides"
+	cost = 1
 	path = /obj/item/toy/dice/d20
 
 /datum/gear/toy/crayon
 	display_name = "Crayon"
+	cost = 1
 	path = /obj/item/toy/crayon/rainbow
 
 /datum/gear/toy/pride
@@ -1449,6 +1452,7 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 /datum/gear/misc/family_photo
 	display_name = "Family photo"
 	path = /obj/item/prop/helmetgarb/family_photo
+	cost = 1
 
 /datum/gear/misc/compass
 	display_name = "Compass"
@@ -1458,6 +1462,7 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 /datum/gear/misc/bug_spray
 	display_name = "Bug spray"
 	path = /obj/item/prop/helmetgarb/bug_spray
+	cost = 1
 
 /datum/gear/misc/straight_razor
 	display_name = "Cut-throat razor"


### PR DESCRIPTION

# About the pull request

Reduced by 1pt some of the point-buy values in Recreational and Miscellaneous:
* Camera Film (0) - camera costs 2 as is.
* Die - 6 & 20 Sided (1)
* Crayon (1)
* Family Photo (1)
* Bug Spray (1)

Previously these were +1 the value listed above

# Explain why it's good for the game

Making some stuff cheaper so it's more attractive to take & RP with. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: made some Recreational stuff cheaper
balance: made some Miscellaneous stuff cheaper
/:cl:

