### PR TITLE
Lets PMC SGs wear scarfs

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1064,7 +1064,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	icon_state = "heavy_helmet"
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	flags_inventory = COVEREYES|COVERMOUTH|BLOCKSHARPOBJ
-	flags_inv_hide = HIDEEARS|HIDEEYES|HIDEFACE|HIDEMASK|HIDEALLHAIR
+	flags_inv_hide = HIDEEARS|HIDEEYES|HIDEFACE|HIDEALLHAIR
 
 /obj/item/clothing/head/helmet/marine/veteran/pmc/commando
 	name = "\improper M5X helmet"


### PR DESCRIPTION
# About the pull request
Removes the HIDEMASK flag from the PMC SG helmet.
# Explain why it's good for the game
Allowing PMC gunners to have scarfs and the like would allow them to be slightly more unique while still wearing their helmet.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/c4433564-2578-473a-b52d-ee510e7d00af)

</details>

# Changelog
:cl:
qol: PMC SGs can now wear scarfs
/:cl: