### PR TITLE
Zombies Keep Their Claws After Delimbing & Reviving

### DIFF
--- a/code/modules/mob/living/carbon/human/species/zombie.dm
+++ b/code/modules/mob/living/carbon/human/species/zombie.dm
@@ -45,10 +45,14 @@
 	zombie.faction = FACTION_ZOMBIE
 	zombie.faction_group = list(FACTION_ZOMBIE)
 
-	if(zombie.wear_id) qdel(zombie.wear_id)
-	if(zombie.gloves) zombie.drop_inv_item_on_ground(zombie.gloves, FALSE, TRUE)
-	if(zombie.head) zombie.drop_inv_item_on_ground(zombie.head, FALSE, TRUE)
-	if(zombie.wear_mask) zombie.drop_inv_item_on_ground(zombie.wear_mask, FALSE, TRUE)
+	if(zombie.wear_id)
+		qdel(zombie.wear_id)
+	if(zombie.gloves)
+		zombie.drop_inv_item_on_ground(zombie.gloves, FALSE, TRUE)
+	if(zombie.head)
+		zombie.drop_inv_item_on_ground(zombie.head, FALSE, TRUE)
+	if(zombie.wear_mask)
+		zombie.drop_inv_item_on_ground(zombie.wear_mask, FALSE, TRUE)
 	equip_zombie_items(zombie) // Handles held items -> claws and glasses -> zombie "eyes"
 
 	var/datum/disease/black_goo/zombie_infection = locate() in zombie.viruses
@@ -157,9 +161,12 @@
 
 /datum/species/zombie/proc/equip_zombie_items(mob/living/carbon/human/zombie)
 	// Drop previous items
-	if(zombie.l_hand) zombie.drop_inv_item_on_ground(zombie.l_hand, FALSE, TRUE)
-	if(zombie.r_hand) zombie.drop_inv_item_on_ground(zombie.r_hand, FALSE, TRUE)
-	if(zombie.glasses) zombie.drop_inv_item_on_ground(zombie.glasses, FALSE, TRUE)
+	if(zombie.l_hand)
+		zombie.drop_inv_item_on_ground(zombie.l_hand, FALSE, TRUE)
+	if(zombie.r_hand)
+		zombie.drop_inv_item_on_ground(zombie.r_hand, FALSE, TRUE)
+	if(zombie.glasses)
+		zombie.drop_inv_item_on_ground(zombie.glasses, FALSE, TRUE)
 
 	// Equip claws and "eyes"
 	var/obj/item/weapon/zombie_claws/ZC = new(zombie)
@@ -169,6 +176,9 @@
 	zombie.equip_to_slot_or_del(new /obj/item/clothing/glasses/zombie_eyes(zombie), WEAR_EYES, TRUE)
 
 /datum/species/zombie/proc/unequip_zombie_items(mob/living/carbon/human/zombie)
-	if(istype(zombie.l_hand, /obj/item/weapon/zombie_claws)) qdel(zombie.l_hand)
-	if(istype(zombie.r_hand, /obj/item/weapon/zombie_claws)) qdel(zombie.r_hand)
-	if(istype(zombie.glasses, /obj/item/clothing/glasses/zombie_eyes)) qdel(zombie.glasses)
+	if(istype(zombie.l_hand, /obj/item/weapon/zombie_claws))
+		qdel(zombie.l_hand)
+	if(istype(zombie.r_hand, /obj/item/weapon/zombie_claws))
+		qdel(zombie.r_hand)
+	if(istype(zombie.glasses, /obj/item/clothing/glasses/zombie_eyes))
+		qdel(zombie.glasses)


### PR DESCRIPTION

# About the pull request
Fixes #1008 

Zombie claws and "eyes" are equipped with a seperate proc that is called on gaining the species as well as when they revive after death. This means that if a limb is lost and then regenerated, the claws remain.

Also adds a proc to unequip zombie items when the species is lost.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes zombies being able to pick up items/do other things they shouldn't if they lose an arm and revive.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Dying and losing left arm/hand
![image](https://github.com/user-attachments/assets/ce57e99a-34cf-4b38-8e3a-dcbc26dc0ad7)
Claws are requipped to the lost limbs after revival
![image](https://github.com/user-attachments/assets/0d35c7bc-84dd-4cf9-acbc-466cc635b1c9)


</details>


# Changelog
:cl:
fix: fixed zombies losing their claws after delimbing and reviving
/:cl:
