### PR TITLE
removes a extra bracket in the smart refil tanks description in the vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -342,7 +342,7 @@ GLOBAL_LIST_INIT(cm_vending_chemical_medic, list(
 		list("Liquid Bottle (Dexalin+)", 40, /obj/item/reagent_container/glass/bottle/dexalinplus, null, VENDOR_ITEM_REGULAR),
 
 		list("INJECTORS", 0, null, null, null),
-		list("Smart Refill Tank"), 40, /obj/item/reagent_container/glass/minitank, null, VENDOR_ITEM_REGULAR),
+		list("Smart Refill Tank", 40, /obj/item/reagent_container/glass/minitank, null, VENDOR_ITEM_REGULAR),
 	))
 
 /obj/structure/machinery/cm_vending/gear/medic_chemical


### PR DESCRIPTION
made a mistake and only noticed it after pr was merged :(
:cl:
spellcheck: removed a extra bracket
