### PR TITLE
Some more /ai subtypes for jobs

### DIFF
--- a/code/game/jobs/job/civilians/support/synthetic.dm
+++ b/code/game/jobs/job/civilians/support/synthetic.dm
@@ -50,3 +50,13 @@
 	name = JOB_SYNTH
 	icon_state = "syn_spawn"
 	job = /datum/job/civilian/synthetic
+
+/datum/job/civilian/synthetic/ai
+	total_positions = 1
+	spawn_positions = 1
+
+/datum/job/civilian/synthetic/ai/set_spawn_positions(count)
+	return spawn_positions
+
+/datum/job/civilian/synthetic/ai/get_total_positions(latejoin=0)
+	return latejoin ? total_positions : spawn_positions

--- a/code/game/jobs/job/marine/squad/engineer.dm
+++ b/code/game/jobs/job/marine/squad/engineer.dm
@@ -1,3 +1,6 @@
+#define LCPL_VARIANT "Lance Corporal"
+#define PFC_VARIANT "Private First Class"
+
 /datum/job/marine/engineer
 	title = JOB_SQUAD_ENGI
 	total_positions = 12
@@ -5,7 +8,10 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/engineer
+	gear_preset_secondary = /datum/equipment_preset/uscm/engineer/pfc
 	entry_message_body = "You have the <a href='"+WIKI_PLACEHOLDER+"'>equipment and skill</a> to build fortifications, reroute power lines, and bunker down. Your squaddies will look to you when it comes to construction in the field of battle."
+
+	job_options = list(PFC_VARIANT = "PFC", LCPL_VARIANT = "LCPL")
 
 /datum/job/marine/engineer/set_spawn_positions(count)
 	for(var/datum/squad/sq in GLOB.RoleAuthority.squads)
@@ -26,6 +32,11 @@
 				sq.max_engineers = slots
 
 	return (slots*4)
+
+/datum/job/marine/engineer/handle_job_options(option)
+	gear_preset = initial(gear_preset)
+	if(option == PFC_VARIANT)
+		gear_preset = gear_preset_secondary
 
 /datum/job/marine/engineer/whiskey
 	title = JOB_WO_SQUAD_ENGINEER
@@ -52,3 +63,16 @@
 /obj/effect/landmark/start/marine/engineer/delta
 	icon_state = "engi_spawn_delta"
 	squad = SQUAD_MARINE_4
+
+/datum/job/marine/engineer/ai
+	total_positions = 2
+	spawn_positions = 2
+
+/datum/job/marine/engineer/ai/set_spawn_positions(count)
+	return spawn_positions
+
+/datum/job/marine/engineer/ai/get_total_positions(latejoin=0)
+	return latejoin ? total_positions : spawn_positions
+
+#undef LCPL_VARIANT
+#undef PFC_VARIANT


### PR DESCRIPTION
# About the pull request

See PR title

# Explain why it's good for the game

Allows GMs to partake in foul witchcraft to have some types of extra roles roll with the initial roundstart, landmark placement permitting.

# Changelog

:cl:
add: ComEng & Synth /ai job subtypes
/:cl:
