### PR TITLE
[TM ONLY] Re-enables & Overhauls Corpse Landmarks

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -8,7 +8,7 @@
 	required_players = 1 //Need at least one player, but really we need 2.
 	xeno_required_num = 1 //Need at least one xeno.
 	monkey_amount = 5
-	corpses_to_spawn = 0
+	corpses_to_spawn = 100
 	flags_round_type = MODE_INFESTATION|MODE_FOG_ACTIVATED|MODE_NEW_SPAWN
 	static_comms_amount = 1
 	var/round_status_flags

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -98,7 +98,11 @@
 	name = "Burst Colonial Marshals Deputy"
 	equip_path = /datum/equipment_preset/corpse/cmb/burst
 
+//*****************************************************************************************************/
 ///////////Faction Specific Corpses//////////////////////
+//*****************************************************************************************************/
+
+/// UPP
 
 /obj/effect/landmark/corpsespawner/upp
 	name = "UPP Squad Rifleman"
@@ -108,6 +112,8 @@
 	name = "Burst UPP Squad Rifleman"
 	equip_path = /datum/equipment_preset/corpse/upp
 
+/// TWE
+
 /obj/effect/landmark/corpsespawner/rmc
 	name = "TWE Squad Rifleman"
 	equip_path = /datum/equipment_preset/corpse/royal_marine
@@ -116,13 +122,7 @@
 	name = "Burst TWE Squad Rifleman"
 	equip_path = /datum/equipment_preset/corpse/royal_marine/burst
 
-/obj/effect/landmark/corpsespawner/uscm
-	name = "USCM Squad Rifleman"
-	equip_path = /datum/equipment_preset/corpse/uscm
-
-/obj/effect/landmark/corpsespawner/uscm/burst
-	name = "Burst USCM Squad Rifleman"
-	equip_path = /datum/equipment_preset/corpse/uscm/burst
+/// Freelancer
 
 /obj/effect/landmark/corpsespawner/freelancer
 	name = "Freelancer"
@@ -132,7 +132,34 @@
 	name = "Burst Freelancer"
 	equip_path = /datum/equipment_preset/corpse/freelancer/burst
 
-///////////FORECON//////////////////////
+/// USCM
+
+/obj/effect/landmark/corpsespawner/uscm
+	name = "USCM Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/uscm
+
+/obj/effect/landmark/corpsespawner/uscm/burst
+	name = "Burst USCM Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/uscm/burst
+
+/obj/effect/landmark/corpsespawner/uscm_dp
+	name = "USCM Dropship Pilot"
+	equip_path = /datum/equipment_preset/corpse/uscm_dp
+
+/obj/effect/landmark/corpsespawner/uscm_dp/burst
+	name = "Burst USCM Dropship Pilot"
+	equip_path = /datum/equipment_preset/corpse/uscm_dp/burst
+
+/obj/effect/landmark/corpsespawner/uscm_unequipped
+	name = "USCM Unequipped Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/uscm_unequipped
+
+/obj/effect/landmark/corpsespawner/uscm_unequipped/burst
+	name = "Burst USCM Unequipped Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/uscm_unequipped/burst
+
+/// FORECON
+
 /obj/effect/landmark/corpsespawner/forecon_spotter
 	name = "USCM Reconnaissance Spotter"
 	equip_path = /datum/equipment_preset/corpse/forecon_spotter

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -16,39 +16,123 @@
 	GLOB.corpse_spawns -= src
 	return ..()
 
+///////////Civilians//////////////////////
+
 /obj/effect/landmark/corpsespawner/bluecollar
-	name = "Corpse - Blue-Collar"
+	name = "Blue-Collar"
 	equip_path = /datum/equipment_preset/corpse/bluecollar
 
+/obj/effect/landmark/corpsespawner/bluecollar/burst
+	name = "Burst Blue-Collar"
+	equip_path = /datum/equipment_preset/corpse/bluecollar/burst
+
 /obj/effect/landmark/corpsespawner/whitecollar
-	name = "Corpse - White-Collar"
+	name = "White-Collar"
 	equip_path = /datum/equipment_preset/corpse/whitecollar
 
-/obj/effect/landmark/corpsespawner/guard
-	name = "Corpse - Security Guard, Prison"
-	equip_path = /datum/equipment_preset/corpse/guard
+/obj/effect/landmark/corpsespawner/whitecollar/burst
+	name = "Burst White-Collar"
+	equip_path = /datum/equipment_preset/corpse/whitecollar/burst
 
-/obj/effect/landmark/corpsespawner/prisoner
-	name = "Corpse - Prisoner"
-	equip_path = /datum/equipment_preset/corpse/prisoner
+/obj/effect/landmark/corpsespawner/researcher
+	name = "Researcher"
+	equip_path = /datum/equipment_preset/corpse/researcher
 
-/obj/effect/landmark/corpsespawner/riot
-	name = "Corpse - Security Guard, UA Colonial Guard"
-	equip_path = /datum/equipment_preset/corpse/riot
+/obj/effect/landmark/corpsespawner/researcher/burst
+	name = "Burst Researcher"
+	equip_path = /datum/equipment_preset/corpse/researcher/burst
 
 /obj/effect/landmark/corpsespawner/doctor
-	name = "Corpse - Doctor"
+	name = "Doctor"
 	equip_path = /datum/equipment_preset/corpse/doctor
 
+/obj/effect/landmark/corpsespawner/doctor/burst
+	name = "Burst Doctor"
+	equip_path = /datum/equipment_preset/corpse/doctor/burst
+
 /obj/effect/landmark/corpsespawner/scrubs
-	name = "Corpse - Doctor, Scrubs"
+	name = "Doctor, Scrubs"
 	equip_path = /datum/equipment_preset/corpse/doctor/scrubs
 
-/obj/effect/landmark/corpsespawner/security
-	name = "Corpse - Security Guard, Wey-Yu"
-	equip_path = /datum/equipment_preset/colonist/corpse/security
+/obj/effect/landmark/corpsespawner/scrubs/burst
+	name = "Burst Doctor, Scrubs"
+	equip_path = /datum/equipment_preset/corpse/doctor/scrubs/burst
 
-//FORECON
+/obj/effect/landmark/corpsespawner/prisoner
+	name = "Prisoner"
+	equip_path = /datum/equipment_preset/corpse/prisoner
+
+/obj/effect/landmark/corpsespawner/prisoner/burst
+	name = "Burst Prisoner"
+	equip_path = /datum/equipment_preset/corpse/prisoner/burst
+
+/obj/effect/landmark/corpsespawner/guard
+	name = "Security Guard, Prison"
+	equip_path = /datum/equipment_preset/corpse/guard
+
+/obj/effect/landmark/corpsespawner/guard/burst
+	name = "Burst Security Guard, Prison"
+	equip_path = /datum/equipment_preset/corpse/guard/burst
+
+/obj/effect/landmark/corpsespawner/riot
+	name = "Security Guard, UA Colonial Guard"
+	equip_path = /datum/equipment_preset/corpse/riot
+
+/obj/effect/landmark/corpsespawner/riot/burst
+	name = "Burst Security Guard, UA Colonial Guard"
+	equip_path = /datum/equipment_preset/corpse/riot/burst
+
+/obj/effect/landmark/corpsespawner/security
+	name = "Security Guard, Wey-Yu"
+	equip_path = /datum/equipment_preset/corpse/security
+
+/obj/effect/landmark/corpsespawner/security/burst
+	name = "Burst Security Guard, Wey-Yu"
+	equip_path = /datum/equipment_preset/corpse/security/burst
+
+/obj/effect/landmark/corpsespawner/cmb
+	name = "Colonial Marshals Deputy"
+	equip_path = /datum/equipment_preset/corpse/cmb
+
+/obj/effect/landmark/corpsespawner/cmb/burst
+	name = "Burst Colonial Marshals Deputy"
+	equip_path = /datum/equipment_preset/corpse/cmb/burst
+
+///////////Faction Specific Corpses//////////////////////
+
+/obj/effect/landmark/corpsespawner/upp
+	name = "UPP Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/upp
+
+/obj/effect/landmark/corpsespawner/upp/burst
+	name = "Burst UPP Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/upp
+
+/obj/effect/landmark/corpsespawner/rmc
+	name = "TWE Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/royal_marine
+
+/obj/effect/landmark/corpsespawner/rmc/burst
+	name = "Burst TWE Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/royal_marine/burst
+
+/obj/effect/landmark/corpsespawner/uscm
+	name = "USCM Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/uscm
+
+/obj/effect/landmark/corpsespawner/uscm/burst
+	name = "Burst USCM Squad Rifleman"
+	equip_path = /datum/equipment_preset/corpse/uscm/burst
+
+/obj/effect/landmark/corpsespawner/freelancer
+	name = "Freelancer"
+	equip_path = /datum/equipment_preset/corpse/freelancer
+
+/obj/effect/landmark/corpsespawner/freelancer/burst
+	name = "Burst Freelancer"
+	equip_path = /datum/equipment_preset/corpse/freelancer/burst
+
+///////////FORECON//////////////////////
 /obj/effect/landmark/corpsespawner/forecon_spotter
 	name = "USCM Reconnaissance Spotter"
 	equip_path = /datum/equipment_preset/corpse/forecon_spotter

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -359,7 +359,7 @@
 	skills = /datum/skills/civilian/survivor/marshal
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_BRIG, ACCESS_CIVILIAN_COMMAND, ACCESS_WY_SECURITY)
 
-/datum/equipment_preset/colonist/corpse/security/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/corpse/security/load_gear(mob/living/carbon/human/new_human)
 
 	new_human.undershirt = "undershirt"
 	//back

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -73,6 +73,7 @@
 
 //*****************************************************************************************************/
 // Civilians
+
 /datum/equipment_preset/corpse/bluecollar
 	name = "Corpse - Blue-Collar"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -415,8 +416,8 @@
 	xenovictim = TRUE
 
 //*****************************************************************************************************/
-
 //UPP
+
 /datum/equipment_preset/corpse/upp/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(60;MALE,40;FEMALE)
 	var/datum/preferences/A = new()
@@ -519,6 +520,9 @@
 	name = "Corpse - UPP Squad Rifleman (Burst)"
 	xenovictim = TRUE
 
+//*****************************************************************************************************/
+//TWE
+
 /datum/equipment_preset/corpse/royal_marine
 	name = "Corpse - TWE Squad Rifleman"
 	paygrades = list(PAY_SHORT_RMC1 = JOB_PLAYTIME_TIER_0)
@@ -551,6 +555,9 @@
 	name = "Corpse - TWE Squad Rifleman (Burst)"
 	xenovictim = TRUE
 
+//*****************************************************************************************************/
+//USCM
+
 /datum/equipment_preset/corpse/uscm
 	name = "Corpse - USCM Squad Rifleman"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -580,8 +587,58 @@
 	name = "Corpse - USCM Squad Rifleman (Burst)"
 	xenovictim = TRUE
 
-//*****************************************************************************************************/
+/datum/equipment_preset/corpse/uscm_dp
+	name = "Corpse - USCM Dropship Pilot"
+	idtype = /obj/item/card/id/dogtag
+	flags = EQUIPMENT_PRESET_EXTRA
+	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PREP)
+	assignment = JOB_DROPSHIP_PILOT
+	rank = JOB_DROPSHIP_PILOT
+	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
+	role_comm_title = "PLT"
+	skills = /datum/skills/pilot
+	minimap_icon = "pilot"
 
+/datum/equipment_preset/corpse/uscm_dp/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/weldingtool(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/wirecutters(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/shovel/etool/folded(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/box/mre(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/upp/marinepilot(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/boiler(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/pilot(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/vp70(new_human), WEAR_J_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full/alternate(new_human), WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/flare/full(new_human), WEAR_R_STORE)
+
+/datum/equipment_preset/corpse/uscm_dp/burst
+	name = "Corpse - USCM Dropship Pilot (Burst)"
+	xenovictim = TRUE
+
+/datum/equipment_preset/corpse/uscm_unequipped	//Used for POWs
+	name = "USCM Squad Rifleman"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND|EQUIPMENT_PRESET_MARINE
+
+	access = list(ACCESS_MARINE_PREP)
+	assignment = JOB_SQUAD_MARINE
+	rank = JOB_SQUAD_MARINE
+	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)
+	role_comm_title = "RFN"
+	skills = /datum/skills/pfc
+
+	minimap_icon = "private"
+	dress_under = list(/obj/item/clothing/under/marine/dress/blues)
+	dress_over = list(/obj/item/clothing/suit/storage/jacket/marine/dress/blues)
+
+/datum/equipment_preset/corpse/uscm_unequipped/burst
+	name = "Corpse - Unequipped USCM Squad Rifleman (Burst)"
+	xenovictim = TRUE
+
+
+//*****************************************************************************************************/
 //Freelancer
 
 /datum/equipment_preset/corpse/freelancer
@@ -613,7 +670,6 @@
 	xenovictim = TRUE
 
 //*****************************************************************************************************/
-
 //FORECON
 
 /datum/equipment_preset/corpse/forecon_spotter

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -620,8 +620,8 @@
 
 /datum/equipment_preset/corpse/uscm_unequipped	//Used for POWs
 	name = "USCM Squad Rifleman"
+	idtype = /obj/item/card/id/dogtag
 	flags = EQUIPMENT_PRESET_START_OF_ROUND|EQUIPMENT_PRESET_MARINE
-
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
 	rank = JOB_SQUAD_MARINE


### PR DESCRIPTION

# About the pull request

Re-enables, re-sorts, and generally overhauls the current state of corpse landmarks. 
This doesn't place landmarks on maps (at the moment) and is more GM/map maker facing changes. 
I'll add more landmarks soon. 

This might not be merged later when modularization occurs. I'll transfer or re-do this whenever that happens. 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Re-enables corpse landmark spawning upon initialization 
add: Re-adds corpse landmarks & organization in the .dm file
/:cl:
