### PR TITLE
active prox_sensor (also in landmines and prox sensor PR)

### DIFF
--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -34,6 +34,15 @@
 	update_icon()
 	return secured
 
+/obj/item/device/assembly/prox_sensor/active
+	name = "armed proximity sensor"
+
+/obj/item/device/assembly/prox_sensor/active/New()
+    ..()
+    secured = TRUE
+    scanning = TRUE
+    update_icon()
+    START_PROCESSING(SSobj, src)
 
 /obj/item/device/assembly/prox_sensor/HasProximity(atom/movable/AM)
 	if((!holder && !secured) || !scanning || cooldown>0 || delaying)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -36,6 +36,7 @@
 
 /obj/item/device/assembly/prox_sensor/active
 	name = "armed proximity sensor"
+	range = 3
 
 /obj/item/device/assembly/prox_sensor/active/New()
     ..()

--- a/code/modules/mob/living/carbon/human/ai/defense_creator.dm
+++ b/code/modules/mob/living/carbon/human/ai/defense_creator.dm
@@ -318,6 +318,12 @@
 	icon_state = "sebb"
 	path_to_spawn = /obj/item/explosive/mine/sebb/active
 
+/datum/human_ai_defense/mine/prox_sensor
+	name = "Proximity Sensor"
+	desc = /obj/item/device/assembly/prox_sensor::desc
+	icon_state = "prox"
+	path_to_spawn = /obj/item/device/assembly/prox_sensor/active
+
 // Barricades
 
 /datum/human_ai_defense/barricade


### PR DESCRIPTION
# About the pull request

Added a prox_sensor subtype that's immediately active. GM can spawn this (the base item is USCM IFF by default) without having to create a mob to enable it via screwdriver.

Also added it to the mines section of the GM Defence Creator Panel, where you can set the IFF

also in #1272 so that'd they would merge together

# Explain why it's good for the game

Bobby mentioned it, I just whipped it together. Would be cool for 'tripwire' esque ops


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: prox_sensor subtype that's already active for GM spawns
/:cl:

